### PR TITLE
Add Environment Variable Support for CLI Arguments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 [dependencies]
 flate2 = "1.0"
 anyhow = "1.0"
-clap = { version = "4.4", features = ["derive"] }
+clap = { version = "4.4", features = ["derive", "env"] }
 reqwest = { version = "0.12", features = ["json", "stream", "multipart", "native-tls-vendored"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,13 @@ mod twitter;
 )]
 struct Cli {
     /// Directory to save the tweet and media
-    #[arg(short, long, default_value = "./downloads", global = true)]
+    #[arg(
+        short,
+        long,
+        default_value = "./downloads",
+        env = "NOSTRWEET_OUTPUT_DIR",
+        global = true
+    )]
     output_dir: PathBuf,
 
     /// Verbose output
@@ -84,15 +90,21 @@ enum Commands {
         tweet_url_or_id: String,
 
         /// Nostr relay addresses to post to (comma-separated)
-        #[arg(short, long, required = true, value_delimiter = ',')]
+        #[arg(
+            short,
+            long,
+            required = true,
+            value_delimiter = ',',
+            env = "NOSTRWEET_RELAYS"
+        )]
         relays: Vec<String>,
 
         /// Blossom server addresses for media uploads (comma-separated)
-        #[arg(short, long, value_delimiter = ',')]
+        #[arg(short, long, value_delimiter = ',', env = "NOSTRWEET_BLOSSOM_SERVERS")]
         blossom_servers: Vec<String>,
 
         /// Nostr private key (hex format, without leading 0x)
-        #[arg(short, long)]
+        #[arg(short, long, env = "NOSTRWEET_PRIVATE_KEY")]
         private_key: Option<String>,
 
         /// Force overwrite of existing Nostr event
@@ -107,15 +119,21 @@ enum Commands {
         username: String,
 
         /// Nostr relay addresses to post to (comma-separated)
-        #[arg(short, long, required = true, value_delimiter = ',')]
+        #[arg(
+            short,
+            long,
+            required = true,
+            value_delimiter = ',',
+            env = "NOSTRWEET_RELAYS"
+        )]
         relays: Vec<String>,
 
         /// Blossom server addresses for media uploads (comma-separated)
-        #[arg(short, long, value_delimiter = ',')]
+        #[arg(short, long, value_delimiter = ',', env = "NOSTRWEET_BLOSSOM_SERVERS")]
         blossom_servers: Vec<String>,
 
         /// Nostr private key (hex format, without leading 0x)
-        #[arg(short, long)]
+        #[arg(short, long, env = "NOSTRWEET_PRIVATE_KEY")]
         private_key: Option<String>,
 
         /// Force overwrite of existing Nostr events
@@ -131,15 +149,21 @@ enum Commands {
         tweet_url_or_id: String,
 
         /// Nostr relay addresses to post to (comma-separated)
-        #[arg(short, long, required = true, value_delimiter = ',')]
+        #[arg(
+            short,
+            long,
+            required = true,
+            value_delimiter = ',',
+            env = "NOSTRWEET_RELAYS"
+        )]
         relays: Vec<String>,
 
         /// Blossom server addresses for media uploads (comma-separated)
-        #[arg(short, long, value_delimiter = ',')]
+        #[arg(short, long, value_delimiter = ',', env = "NOSTRWEET_BLOSSOM_SERVERS")]
         blossom_servers: Vec<String>,
 
         /// Nostr private key (hex format, without leading 0x)
-        #[arg(short, long)]
+        #[arg(short, long, env = "NOSTRWEET_PRIVATE_KEY")]
         private_key: Option<String>,
 
         /// Force overwrite of existing Nostr event
@@ -154,22 +178,34 @@ enum Commands {
         username: String,
 
         /// Nostr relay addresses to post to (comma-separated)
-        #[arg(short, long, required = true, value_delimiter = ',')]
+        #[arg(
+            short,
+            long,
+            required = true,
+            value_delimiter = ',',
+            env = "NOSTRWEET_RELAYS"
+        )]
         relays: Vec<String>,
 
         /// Nostr private key (hex format, without leading 0x)
-        #[arg(short, long)]
+        #[arg(short, long, env = "NOSTRWEET_PRIVATE_KEY")]
         private_key: Option<String>,
     },
 
     /// Update the relay list on Nostr
     UpdateRelayList {
         /// Nostr relay addresses to post to (comma-separated)
-        #[arg(short, long, required = true, value_delimiter = ',')]
+        #[arg(
+            short,
+            long,
+            required = true,
+            value_delimiter = ',',
+            env = "NOSTRWEET_RELAYS"
+        )]
         relays: Vec<String>,
 
         /// Nostr private key (hex format, without leading 0x)
-        #[arg(short, long)]
+        #[arg(short, long, env = "NOSTRWEET_PRIVATE_KEY")]
         private_key: Option<String>,
     },
 


### PR DESCRIPTION
## Add Environment Variable Support for CLI Arguments

### Description

This PR adds support for configuring common CLI arguments through environment variables, significantly improving the user experience for users who frequently run nostrweet commands with the same parameters.

### Changes

1. **Added `env` feature to clap dependency** in `Cargo.toml`
2. **Added environment variable support** to the following CLI arguments:
   - `--output-dir` → `NOSTRWEET_OUTPUT_DIR`
   - `--relays` → `NOSTRWEET_RELAYS`
   - `--blossom-servers` → `NOSTRWEET_BLOSSOM_SERVERS`
   - `--private-key` → `NOSTRWEET_PRIVATE_KEY`

### Motivation

Users often need to specify the same values for relays, private keys, and output directories across multiple command invocations. Having to type these repeatedly is error-prone and tedious. With environment variables, users can set their preferences once and simplify their commands.

### Usage Examples

**Before:**
```bash
nostrweet post-tweet-to-nostr --output-dir=/my/tweets --relays=wss://relay1.com,wss://relay2.com --blossom-servers=https://blossom.server.com --private-key=abc123 1234567890

nostrweet post-user-to-nostr --output-dir=/my/tweets --relays=wss://relay1.com,wss://relay2.com --blossom-servers=https://blossom.server.com --private-key=abc123 @username
```

**After:**
```bash
# Set environment variables once
export NOSTRWEET_OUTPUT_DIR="/my/tweets"
export NOSTRWEET_RELAYS="wss://relay1.com,wss://relay2.com"
export NOSTRWEET_BLOSSOM_SERVERS="https://blossom.server.com"
export NOSTRWEET_PRIVATE_KEY="abc123"

# Much simpler commands
nostrweet post-tweet-to-nostr 1234567890
nostrweet post-user-to-nostr @username
```

### Behavior

- **Priority:** CLI arguments always take precedence over environment variables
- **Compatibility:** Fully backward compatible - existing scripts and workflows continue to work unchanged
- **Help text:** Environment variables are displayed in `--help` output when set

### Testing

All existing tests pass. The feature has been manually tested with:
- Individual environment variables
- Multiple environment variables together
- CLI arguments overriding environment variables
- Help text display

### Affected Commands

Environment variables are supported in the following commands:
- `post-tweet-to-nostr` (all 4 env vars)
- `post-user-to-nostr` (all 4 env vars)
- `post-tweet` (all 4 env vars)
- `post-profile-to-nostr` (output-dir, relays, private-key)
- `update-relay-list` (relays, private-key)
- All other commands support `NOSTRWEET_OUTPUT_DIR`