### PR TITLE
Add GitHub CLI to Nix development environment

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
             findutils
             gnugrep
             gnused
+            gh
           ];
 
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER = "${pkgs.pkgsStatic.stdenv.cc}/bin/${pkgs.pkgsStatic.stdenv.cc.targetPrefix}cc";


### PR DESCRIPTION
Add GitHub CLI (gh) to the development shell to enable PR creation and management directly from the development environment.

This is a test PR to verify that GitHub workflows are running correctly after the branch name fixes.