### PR TITLE
fix: formatting issue in post_tweet_to_nostr.rs

### DIFF
--- a/src/commands/post_tweet_to_nostr.rs
+++ b/src/commands/post_tweet_to_nostr.rs
@@ -116,7 +116,7 @@ pub async fn execute(
                         id = ref_tweet.id,
                         dir = output_dir.display()
                     );
-                    
+
                     // First check in the current output directory
                     let mut existing_path =
                         storage::find_existing_tweet_json(&ref_tweet.id, output_dir);


### PR DESCRIPTION
Remove trailing whitespace that was causing CI formatting check to fail on master after PR #8 was merged.