### PR TITLE
chore: remove dead code and unused functions

### DIFF
--- a/src/datetime_utils.rs
+++ b/src/datetime_utils.rs
@@ -56,12 +56,6 @@ pub fn now_utc() -> DateTime<Utc> {
     Utc::now()
 }
 
-/// Get current Unix timestamp (seconds since epoch)
-#[allow(dead_code)]
-pub fn unix_timestamp_now() -> i64 {
-    Utc::now().timestamp()
-}
-
 /// Convert Unix timestamp to DateTime
 pub fn from_unix_timestamp(timestamp: i64) -> DateTime<Utc> {
     DateTime::from_timestamp(timestamp, 0).unwrap_or_else(|| {

--- a/src/error_utils.rs
+++ b/src/error_utils.rs
@@ -1,53 +1,7 @@
 use anyhow::{Context, Result};
 use serde::{de::DeserializeOwned, Serialize};
-use std::path::Path;
-use tokio::fs;
 
 /// File I/O error handling utilities
-///
-/// Write content to a file with contextual error handling
-#[allow(dead_code)]
-pub async fn write_file_with_context<P: AsRef<Path>>(
-    file_path: P,
-    content: &str,
-    operation_desc: &str,
-) -> Result<()> {
-    fs::write(&file_path, content).await.with_context(|| {
-        format!(
-            "Failed to write {operation_desc} to {}",
-            file_path.as_ref().display()
-        )
-    })
-}
-
-/// Read file to string with contextual error handling
-#[allow(dead_code)]
-pub async fn read_file_to_string_with_context<P: AsRef<Path>>(
-    file_path: P,
-    operation_desc: &str,
-) -> Result<String> {
-    fs::read_to_string(&file_path).await.with_context(|| {
-        format!(
-            "Failed to read {operation_desc} from {}",
-            file_path.as_ref().display()
-        )
-    })
-}
-
-/// Create directory (and parents) with contextual error handling
-#[allow(dead_code)]
-pub async fn create_dir_all_with_context<P: AsRef<Path>>(
-    dir_path: P,
-    dir_desc: &str,
-) -> Result<()> {
-    fs::create_dir_all(&dir_path).await.with_context(|| {
-        format!(
-            "Failed to create {dir_desc} directory at {}",
-            dir_path.as_ref().display()
-        )
-    })
-}
-
 /// JSON serialization/parsing error handling utilities
 ///
 /// Serialize data to pretty JSON with contextual error handling
@@ -106,41 +60,11 @@ pub fn create_http_client_with_context() -> Result<reqwest::Client> {
 mod tests {
     use super::*;
     use serde::{Deserialize, Serialize};
-    use tempfile::TempDir;
 
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
     struct TestData {
         name: String,
         value: i32,
-    }
-
-    #[tokio::test]
-    async fn test_write_and_read_file_with_context() {
-        let temp_dir = TempDir::new().unwrap();
-        let file_path = temp_dir.path().join("test.txt");
-        let content = "Hello, world!";
-
-        // Test writing
-        write_file_with_context(&file_path, content, "test data")
-            .await
-            .unwrap();
-
-        // Test reading
-        let read_content = read_file_to_string_with_context(&file_path, "test data")
-            .await
-            .unwrap();
-        assert_eq!(read_content, content);
-    }
-
-    #[tokio::test]
-    async fn test_create_dir_all_with_context() {
-        let temp_dir = TempDir::new().unwrap();
-        let nested_path = temp_dir.path().join("nested").join("directory");
-
-        create_dir_all_with_context(&nested_path, "nested test")
-            .await
-            .unwrap();
-        assert!(nested_path.exists());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,7 +135,6 @@ enum Commands {
         force: bool,
     },
 
-    /// Post a user's latest cached profile to Nostr
     /// Post a single tweet to Nostr relays
     PostTweet {
         /// URL or ID of the tweet to post to Nostr

--- a/src/nostr.rs
+++ b/src/nostr.rs
@@ -567,7 +567,7 @@ fn expand_urls_in_text(
                         }
                     } else {
                         // Non-media URL: use regular expansion with markdown format
-                        if let Ok(_parsed_url) = UrlParser::parse(&url_entity.expanded_url) {
+                        if UrlParser::parse(&url_entity.expanded_url).is_ok() {
                             result = result.replace(
                                 &url_entity.url,
                                 &format!(
@@ -643,9 +643,9 @@ fn analyze_retweet(tweet: &crate::twitter::Tweet) -> (bool, Option<String>) {
         return (false, None);
     };
 
-    let Some(_retweet) = ref_tweets.iter().find(|rt| rt.type_field == "retweeted") else {
+    if !ref_tweets.iter().any(|rt| rt.type_field == "retweeted") {
         return (false, None);
-    };
+    }
 
     // Pure retweets typically start with "RT @username:"
     let raw_text = if let Some(note) = &tweet.note_tweet {


### PR DESCRIPTION
## Summary
This PR removes dead code and unused functions identified through static analysis of the codebase.

## Changes
- **error_utils.rs**: Removed 3 unused file I/O helper functions that were marked with `#[allow(dead_code)]` and only used in their own tests
- **datetime_utils.rs**: Removed `unix_timestamp_now()` function that was marked with `#[allow(dead_code)]` and never used
- **main.rs**: Fixed duplicate/conflicting command documentation
- **nostr.rs**: Replaced unused variables with more idiomatic patterns (`.is_ok()` and `.any()`)
- **media.rs**: Removed unused parameters from internal functions and unnecessary `.enumerate()` calls

## Test Plan
- [x] All existing tests pass
- [x] `cargo clippy` passes without warnings
- [x] `cargo fmt` applied
- [x] No functionality changes - only dead code removal

## Impact
This cleanup removes ~95 lines of unused code, making the codebase leaner and easier to maintain. No user-facing changes.