### PR TITLE
fix: decode HTML entities in tweet text

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ base64 = "0.21"
 rand = "0.9.1"
 backoff = { version = "0.4.0", features = ["tokio"] }
 glob = "0.3.2"
+html-escape = "0.2"
 
 [dev-dependencies]
 tempfile = "3.8"


### PR DESCRIPTION
## Summary
Fixes HTML entities (like `&gt;`, `&lt;`, `&amp;`) appearing literally in Nostr posts instead of being decoded to their actual characters.

## Problem
When tweets containing HTML entities are posted to Nostr, the entities appear as-is rather than being decoded. For example:
- Tweet text: `"Boa ditadura &gt; Democracia mediana"`
- Appears in Nostr as: `"Boa ditadura &gt; Democracia mediana"`
- Should appear as: `"Boa ditadura > Democracia mediana"`

## Solution
- Added `html-escape` dependency for reliable HTML entity decoding
- Implemented `decode_html_entities` function that decodes all standard HTML entities
- Applied decoding at the beginning of tweet text processing pipeline (before URL expansion and mention processing)
- Works for both regular tweets and note_tweets (extended tweets)

## Test Plan
- [x] Added unit test for `decode_html_entities` function covering common entities
- [x] Added integration test `test_format_tweet_with_html_entities` to verify entities are decoded in formatted output
- [x] All existing tests pass
- [x] Manual testing with the example tweet confirms the fix

## Example
Before: `@bitcoineaqui @rafaela_cnf Boa ditadura &gt; Democracia mediana`
After: `@bitcoineaqui @rafaela_cnf Boa ditadura > Democracia mediana`