### PR TITLE
feat: auto-post referenced user profiles to Nostr

### DIFF
--- a/src/commands/post_tweet.rs
+++ b/src/commands/post_tweet.rs
@@ -8,6 +8,7 @@ pub async fn execute(
     private_key: Option<&str>,
     output_dir: &Path,
     force: bool,
+    skip_profiles: bool,
 ) -> Result<()> {
     super::post_tweet_to_nostr::execute(
         tweet_url_or_id,
@@ -16,6 +17,7 @@ pub async fn execute(
         private_key,
         output_dir,
         force,
+        skip_profiles,
     )
     .await
     .context("Failed to post tweet to Nostr")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod keys;
 pub mod media;
 pub mod nostr;
 pub mod nostr_linking;
+pub mod nostr_profile;
 pub mod profile_collector;
 pub mod storage;
 pub mod twitter;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod keys;
 mod media;
 mod nostr;
 mod nostr_linking;
+mod nostr_profile;
 mod profile_collector;
 mod storage;
 mod twitter;
@@ -114,6 +115,10 @@ enum Commands {
         /// Force overwrite of existing Nostr event
         #[arg(short, long)]
         force: bool,
+
+        /// Skip posting profiles for referenced users
+        #[arg(long, default_value = "false")]
+        skip_profiles: bool,
     },
 
     /// Post all cached tweets for a user to Nostr relays
@@ -143,6 +148,10 @@ enum Commands {
         /// Force overwrite of existing Nostr events
         #[arg(short, long)]
         force: bool,
+
+        /// Skip posting profiles for referenced users
+        #[arg(long, default_value = "false")]
+        skip_profiles: bool,
     },
 
     /// Post a single tweet to Nostr relays
@@ -172,6 +181,10 @@ enum Commands {
         /// Force overwrite of existing Nostr event
         #[arg(short, long)]
         force: bool,
+
+        /// Skip posting profiles for referenced users
+        #[arg(long, default_value = "false")]
+        skip_profiles: bool,
     },
 
     /// Post a user's latest cached profile to Nostr
@@ -283,6 +296,7 @@ async fn main() -> Result<()> {
             blossom_servers,
             private_key,
             force,
+            skip_profiles,
         } => {
             commands::post_tweet_to_nostr::execute(
                 &tweet_url_or_id,
@@ -291,6 +305,7 @@ async fn main() -> Result<()> {
                 private_key.as_deref(),
                 &output_dir,
                 force,
+                skip_profiles,
             )
             .await?
         }
@@ -300,6 +315,7 @@ async fn main() -> Result<()> {
             blossom_servers,
             private_key,
             force,
+            skip_profiles,
         } => {
             commands::post_user_to_nostr::execute(
                 &username,
@@ -308,6 +324,7 @@ async fn main() -> Result<()> {
                 private_key.as_deref(),
                 &output_dir,
                 force,
+                skip_profiles,
             )
             .await?
         }
@@ -317,6 +334,7 @@ async fn main() -> Result<()> {
             blossom_servers,
             private_key,
             force,
+            skip_profiles,
         } => {
             commands::post_tweet::execute(
                 &tweet_url_or_id,
@@ -325,6 +343,7 @@ async fn main() -> Result<()> {
                 private_key.as_deref(),
                 &output_dir,
                 force,
+                skip_profiles,
             )
             .await?
         }

--- a/src/nostr_profile.rs
+++ b/src/nostr_profile.rs
@@ -1,0 +1,178 @@
+use anyhow::{Context, Result};
+use nostr_sdk::{prelude::*, Metadata};
+use std::collections::HashSet;
+use std::path::Path;
+use tracing::{debug, info};
+
+use crate::{keys, storage};
+
+/// Posts a Twitter user profile to Nostr as metadata
+async fn post_single_profile(
+    username: &str,
+    client: &nostr_sdk::Client,
+    output_dir: &Path,
+    private_key: Option<&str>,
+) -> Result<EventId> {
+    debug!("Attempting to post profile for @{username} to Nostr");
+
+    // Find the latest profile for the user
+    let profile_path = storage::find_latest_user_profile(username, output_dir)?
+        .ok_or_else(|| anyhow::anyhow!("No profile found for user '{username}'"))?;
+
+    debug!(
+        "Found profile for @{username} at {path}",
+        path = profile_path.display()
+    );
+
+    // Load the user profile
+    let user = storage::load_user_from_file(&profile_path)
+        .with_context(|| format!("Failed to load profile for @{username}"))?;
+
+    // Get Nostr keys for this user
+    let user_keys = keys::get_keys_for_tweet(&user.id, private_key)?;
+
+    // Create metadata
+    let mut metadata = Metadata::new();
+    if let Some(name) = user.name {
+        metadata = metadata.name(name);
+    }
+
+    let disclaimer = format!("\n\nThis account is a mirror of https://x.com/{username}");
+    let about = match user.description {
+        Some(d) => format!("{d}{disclaimer}"),
+        None => disclaimer,
+    };
+    metadata = metadata.about(&about);
+
+    if let Some(profile_image_url) = user.profile_image_url {
+        if let Ok(url) = Url::parse(&profile_image_url) {
+            metadata = metadata.picture(url);
+        }
+    }
+
+    if let Some(url) = user.url {
+        if let Ok(url) = Url::parse(&url) {
+            metadata = metadata.website(url);
+        }
+    }
+
+    // Build the event
+    let event = EventBuilder::metadata(&metadata)
+        .sign(&user_keys)
+        .await
+        .context("Failed to build metadata event")?;
+
+    // Save the event locally
+    storage::save_nostr_event(&event, output_dir)
+        .context("Failed to save nostr profile event locally")?;
+
+    // Publish the event
+    let output = client
+        .send_event(&event)
+        .await
+        .with_context(|| format!("Failed to publish profile for @{username} to Nostr"))?;
+
+    // Extract the event ID from the output
+    let event_id = *output.id();
+
+    debug!("Successfully published profile for @{username} with event ID: {event_id:?}");
+
+    Ok(event_id)
+}
+
+/// Posts profiles for all referenced users in a tweet to Nostr
+/// Returns the number of profiles successfully posted
+pub async fn post_referenced_profiles(
+    usernames: &HashSet<String>,
+    client: &nostr_sdk::Client,
+    output_dir: &Path,
+    private_key: Option<&str>,
+) -> Result<usize> {
+    if usernames.is_empty() {
+        return Ok(0);
+    }
+
+    info!(
+        "Posting {} referenced user profiles to Nostr",
+        usernames.len()
+    );
+
+    let mut posted_count = 0;
+    let mut failed_count = 0;
+
+    for username in usernames {
+        match post_single_profile(username, client, output_dir, private_key).await {
+            Ok(event_id) => {
+                debug!("Posted profile for @{username} with event ID: {event_id:?}");
+                posted_count += 1;
+            }
+            Err(e) => {
+                // Log the error but continue with other profiles
+                debug!("Failed to post profile for @{username}: {e}");
+                failed_count += 1;
+            }
+        }
+    }
+
+    if failed_count > 0 {
+        debug!("Posted {posted_count} profiles, {failed_count} failed",);
+    }
+
+    if posted_count > 0 {
+        info!("Successfully posted {posted_count} user profiles to Nostr");
+    }
+
+    Ok(posted_count)
+}
+
+/// Check which profiles need to be posted (not already posted or outdated)
+/// Returns a set of usernames that should be posted
+pub async fn filter_profiles_to_post(
+    usernames: HashSet<String>,
+    client: &nostr_sdk::Client,
+    output_dir: &Path,
+    private_key: Option<&str>,
+    force: bool,
+) -> Result<HashSet<String>> {
+    if force {
+        // If force flag is set, post all profiles
+        return Ok(usernames);
+    }
+
+    let mut profiles_to_post = HashSet::new();
+
+    for username in usernames {
+        // Check if profile exists locally
+        if storage::find_latest_user_profile(&username, output_dir)?.is_none() {
+            debug!("Profile for @{username} not found locally, skipping");
+            continue;
+        }
+
+        // Load the user profile to get the user ID
+        let profile_path = storage::find_latest_user_profile(&username, output_dir)?
+            .ok_or_else(|| anyhow::anyhow!("Profile path disappeared for {username}"))?;
+
+        let user = storage::load_user_from_file(&profile_path)?;
+        let user_keys = keys::get_keys_for_tweet(&user.id, private_key)?;
+        let pubkey = user_keys.public_key();
+
+        // Check if we've already posted a profile for this user
+        // Query for metadata events (Kind 0) from this pubkey
+        let filter = Filter::new().author(pubkey).kind(Kind::Metadata).limit(1);
+
+        // Try to query the database for existing events
+        let has_existing_profile = match client.database().query(filter).await {
+            Ok(events) => !events.is_empty(),
+            Err(_) => false, // Assume no profile if we can't query
+        };
+
+        if !has_existing_profile {
+            debug!("No existing profile found for @{username}, will post");
+            profiles_to_post.insert(username);
+        } else {
+            debug!("Profile already exists for @{username}, skipping");
+        }
+    }
+
+    Ok(profiles_to_post)
+}


### PR DESCRIPTION
## Summary
This PR adds automatic posting of referenced user profiles to Nostr when posting tweets. When a tweet references other users (through mentions, retweets, replies, or quotes), their profiles are automatically posted as Nostr metadata events to ensure a complete social graph.

## Changes
- **New `nostr_profile` module**: Handles posting Twitter user profiles as Nostr metadata events
- **Profile posting in post_tweet_to_nostr**: Posts profiles for all users referenced in the tweet
- **Batch profile posting in post_user_to_nostr**: Collects all referenced users across all tweets and posts profiles in batch
- **Duplicate detection**: Checks if profiles already exist on Nostr before posting
- **CLI control**: Added `--skip-profiles` flag to all posting commands to disable profile posting if needed

## Benefits
- **Complete social graph**: Ensures all referenced users have their profiles on Nostr
- **Better UX**: Nostr clients can display proper user information for mentions
- **Efficient**: Batches profile posting and avoids duplicates
- **Flexible**: Can be disabled with `--skip-profiles` flag if not needed

## Technical Details
- Profiles are posted as Kind 0 (Metadata) events
- Each Twitter user gets a deterministic Nostr key based on their Twitter user ID
- Profile includes name, bio, profile image, and website from Twitter
- Adds disclaimer that the account is a mirror of the Twitter account

## Test Plan
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Code passes all quality checks (fmt, clippy)
- [x] Manual testing with posting tweets containing mentions

## Example Usage
```bash
# Post tweet with automatic profile posting for referenced users (default)
nostrweet post-tweet-to-nostr https://twitter.com/user/status/123 --relays wss://relay.example.com

# Skip profile posting if desired
nostrweet post-tweet-to-nostr https://twitter.com/user/status/123 --relays wss://relay.example.com --skip-profiles

# Post all tweets for a user with batch profile posting
nostrweet post-user-to-nostr @username --relays wss://relay.example.com

# Skip profiles when posting user's tweets
nostrweet post-user-to-nostr @username --relays wss://relay.example.com --skip-profiles
```

## Related
This PR works best when combined with #17 (auto-download referenced profiles) as it ensures the profiles are available locally before attempting to post them to Nostr.