### PR TITLE
fix: daemon posts referenced profiles for cached tweets

### DIFF
--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -427,6 +427,19 @@ async fn process_user_tweets(state: &DaemonState, username: &str) -> Result<(u64
                         .is_ok()
                     {
                         posted_to_nostr_count += 1;
+
+                        // Also post referenced profiles for cached tweets
+                        let referenced_usernames =
+                            profile_collector::collect_usernames_from_tweet(&cached_tweet);
+                        if !referenced_usernames.is_empty() {
+                            let _ = nostr_profile::post_referenced_profiles(
+                                &referenced_usernames,
+                                &state.nostr_client,
+                                &state.config.output_dir,
+                                state.config.private_key.as_deref(),
+                            )
+                            .await;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
Fixes the daemon to post referenced user profiles when posting cached tweets to Nostr.

## Problem
The daemon was only posting referenced profiles (mentioned users, quoted tweet authors, etc.) for new tweets. When cached tweets were posted to Nostr, their referenced profiles were not being posted.

This created an inconsistency where:
- New tweets → profiles posted ✅
- Cached tweets → profiles NOT posted ❌

## Solution
Added the same profile posting logic that exists for new tweets to the cached tweet handling section.

## Changes
- After successfully posting a cached tweet to Nostr, collect referenced usernames
- Post those profiles using `nostr_profile::post_referenced_profiles()`

## Testing
- Code formatted with `cargo fmt`
- All clippy checks pass
- All tests pass

## Impact
This ensures that all mentioned users and referenced tweet authors have their profiles posted to Nostr consistently, regardless of whether the tweet was new or cached.