### PR TITLE
fix(cargo-deny): update configuration to fix CI failures

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -23,6 +23,12 @@ ignore = [
     # instant is unmaintained but only used by backoff crate for tokio feature
     # This is not a security vulnerability, just an unmaintained crate
     "RUSTSEC-2024-0384",
+    # backoff is unmaintained but still works fine for our use case
+    # We can consider migrating to backon in the future
+    "RUSTSEC-2025-0012",
+    # dotenv is unmaintained but we're only using it for dev environments
+    # Consider migrating to dotenvy in the future
+    "RUSTSEC-2021-0141",
 ]
 
 [licenses]
@@ -39,6 +45,8 @@ allow = [
     "ISC",
     "CC0-1.0",
     "Unlicense",
+    "Unicode-3.0",
+    "CDLA-Permissive-2.0",
 ]
 
 # Exceptions for specific crates


### PR DESCRIPTION
## Summary
Fixes the failing cargo-deny CI checks that were preventing builds from passing.

## Changes
- Added `Unicode-3.0` license to allowed list (used by icu_collections crate)
- Added `CDLA-Permissive-2.0` license to allowed list (used by webpki-roots crate)  
- Ignored unmaintained advisory for `backoff` crate (RUSTSEC-2025-0012)
- Ignored unmaintained advisory for `dotenv` crate (RUSTSEC-2021-0141)

## Context
The CI was failing due to:
1. New license requirements from dependencies not being in the allowed list
2. Unmaintained advisories for packages that still work fine for our use case

## Test Plan
- [x] Ran `cargo deny check` locally - all checks pass
- [x] Verified cargo-deny configuration is correct

Fixes: https://github.com/douglaz/nostrweet/actions/runs/17016368549