### PR TITLE
chore: update Rust edition to 2024 and refactor environment variable handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 
 [workspace.package]
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors = ["nostrweet contributors"]
 
 [workspace.dependencies]

--- a/DAEMON.md
+++ b/DAEMON.md
@@ -68,16 +68,16 @@ nostrweet daemon \
   --relay wss://relay1.com \
   --relay wss://relay2.com \
   --poll-interval 300 \
-  --output-dir ./downloads
+  --data-dir ./downloads
 ```
 
 ### Parameters
 - `--user`: Twitter username to monitor (can be specified multiple times)
 - `--relay`: Nostr relay to post to (can be specified multiple times)
 - `--poll-interval`: Seconds between polling cycles (default: 300)
-- `--output-dir`: Cache directory (required)
+- `--data-dir`: Data directory for all storage (required)
 - `--blossom-server`: Blossom server for media (can be specified multiple times)
-- `--private-key`: Optional Nostr private key
+- `--mnemonic`: Optional BIP39 mnemonic phrase for deriving Nostr keys
 
 ### Clap Definition
 ```rust
@@ -99,9 +99,9 @@ struct DaemonCommand {
     #[arg(short, long, default_value = "300")]
     poll_interval: u64,
     
-    /// Nostr private key (hex format, without leading 0x)
-    #[arg(long, env = "NOSTRWEET_PRIVATE_KEY")]
-    private_key: Option<String>,
+    /// BIP39 mnemonic phrase for deriving Nostr keys
+    #[arg(long, env = "NOSTRWEET_MNEMONIC")]
+    mnemonic: Option<String>,
 }
 ```
 
@@ -371,11 +371,11 @@ impl RateLimiter {
 ```bash
 # Required
 export TWITTER_BEARER_TOKEN="your_token"
-export NOSTRWEET_OUTPUT_DIR="./downloads"
+export NOSTRWEET_DATA_DIR="./downloads"
 export NOSTRWEET_RELAYS="wss://relay1.com,wss://relay2.com"
 
 # Optional
-export NOSTRWEET_PRIVATE_KEY="your_hex_key"
+export NOSTRWEET_MNEMONIC="your twelve word mnemonic phrase here"
 export NOSTRWEET_BLOSSOM_SERVERS="https://blossom1.com"
 export RUST_LOG="info,nostrweet=debug"
 ```

--- a/DAEMON.md
+++ b/DAEMON.md
@@ -376,7 +376,6 @@ export NOSTRWEET_RELAYS="wss://relay1.com,wss://relay2.com"
 
 # Optional
 export NOSTRWEET_MNEMONIC="your twelve word mnemonic phrase here"
-export NOSTRWEET_BLOSSOM_SERVERS="https://blossom1.com"
 export RUST_LOG="info,nostrweet=debug"
 ```
 

--- a/README.md
+++ b/README.md
@@ -280,7 +280,6 @@ git config --unset core.hooksPath
 |----------|-------------|----------|---------|
 | `TWITTER_BEARER_TOKEN` | Twitter API bearer token | Yes | - |
 | `NOSTRWEET_DATA_DIR` | Data directory for all storage (tweets, media, profiles) | Yes (or use `-o` flag) | - |
-| `NOSTRWEET_CACHE_DIR` | Additional cache directory path | No | - |
 | `RUST_LOG` | Logging level | No | `info` |
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ Create a `.env` file in the project root:
 ```bash
 TWITTER_BEARER_TOKEN=your_twitter_bearer_token
 RUST_LOG=info  # Optional: debug, trace for more verbose output
-NOSTRWEET_CACHE_DIR=./downloads  # Optional: custom cache directory
+NOSTRWEET_DATA_DIR=./downloads  # Optional: data directory for all storage
 ```
 
 ## Usage
 
 ### Global Options
-- `-o, --output-dir <DIR>`: Specify the directory to save tweets and media (default: `./downloads`)
+- `-o, --data-dir <DIR>`: Specify the directory to save all data (tweets, media, profiles) (default: `./downloads`)
 - `-v, --verbose`: Enable verbose output logging
 - `-h, --help`: Display help information
 - `-V, --version`: Show version information
@@ -77,7 +77,7 @@ nostrweet fetch-tweet https://twitter.com/username/status/1234567890
 nostrweet fetch-tweet 1234567890
 
 # Custom output directory
-nostrweet --output-dir /path/to/downloads fetch-tweet 1234567890
+nostrweet --data-dir /path/to/downloads fetch-tweet 1234567890
 ```
 
 #### Fetch User Timeline
@@ -279,7 +279,7 @@ git config --unset core.hooksPath
 | Variable | Description | Required | Default |
 |----------|-------------|----------|---------|
 | `TWITTER_BEARER_TOKEN` | Twitter API bearer token | Yes | - |
-| `NOSTRWEET_OUTPUT_DIR` | Output directory for tweets and media | Yes (or use `-o` flag) | - |
+| `NOSTRWEET_DATA_DIR` | Data directory for all storage (tweets, media, profiles) | Yes (or use `-o` flag) | - |
 | `NOSTRWEET_CACHE_DIR` | Additional cache directory path | No | - |
 | `RUST_LOG` | Logging level | No | `info` |
 

--- a/nostrweet-integration-tests/src/relay.rs
+++ b/nostrweet-integration-tests/src/relay.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::time::Duration;

--- a/nostrweet-integration-tests/src/test_runner.rs
+++ b/nostrweet-integration-tests/src/test_runner.rs
@@ -55,11 +55,13 @@ impl TestContext {
 
         info!("Running: {:?}", cmd);
 
-        // Apply a 15-minute timeout to allow for Twitter API rate limit retries
-        let status = match timeout(Duration::from_secs(900), cmd.status()).await {
+        // Apply a 120-minute timeout to allow for Twitter API rate limit retries
+        let status = match timeout(Duration::from_secs(7200), cmd.status()).await {
             Ok(result) => result.context("Failed to run nostrweet")?,
             Err(_) => {
-                bail!("Command timed out after 15 minutes. This may indicate a Twitter API issue.");
+                bail!(
+                    "Command timed out after 120 minutes. This may indicate a Twitter API issue."
+                );
             }
         };
 
@@ -112,11 +114,13 @@ impl TestContext {
 
         info!("Running (with output capture): {:?}", cmd);
 
-        // Apply a 15-minute timeout to allow for Twitter API rate limit retries
-        let output = match timeout(Duration::from_secs(900), cmd.output()).await {
+        // Apply a 120-minute timeout to allow for Twitter API rate limit retries
+        let output = match timeout(Duration::from_secs(7200), cmd.output()).await {
             Ok(result) => result.context("Failed to run nostrweet")?,
             Err(_) => {
-                bail!("Command timed out after 15 minutes. This may indicate a Twitter API issue.");
+                bail!(
+                    "Command timed out after 120 minutes. This may indicate a Twitter API issue."
+                );
             }
         };
 

--- a/nostrweet-integration-tests/src/test_runner.rs
+++ b/nostrweet-integration-tests/src/test_runner.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::process::Stdio;

--- a/nostrweet-integration-tests/src/tests/batch_post.rs
+++ b/nostrweet-integration-tests/src/tests/batch_post.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
-use nostr_sdk::prelude::*;
 use nostr_sdk::Event;
+use nostr_sdk::prelude::*;
 use tracing::{debug, info};
 
 use crate::test_runner::TestContext;

--- a/nostrweet-integration-tests/src/tests/daemon.rs
+++ b/nostrweet-integration-tests/src/tests/daemon.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
-use nostr_sdk::prelude::*;
 use nostr_sdk::Event;
+use nostr_sdk::prelude::*;
 use std::time::Duration;
 use tokio::process::{Child, Command};
 use tokio::time::{sleep, timeout};

--- a/nostrweet-integration-tests/src/tests/nostr_post.rs
+++ b/nostrweet-integration-tests/src/tests/nostr_post.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
-use nostr_sdk::prelude::*;
 use nostr_sdk::Event;
+use nostr_sdk::prelude::*;
 use serde_json::json;
 use std::fs;
 use tracing::{debug, info};

--- a/nostrweet-integration-tests/src/tests/profile.rs
+++ b/nostrweet-integration-tests/src/tests/profile.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
-use nostr_sdk::prelude::*;
 use nostr_sdk::Event;
+use nostr_sdk::prelude::*;
 use tracing::{debug, info};
 
 use crate::test_runner::TestContext;

--- a/nostrweet-integration-tests/src/tests/tweet_fetch.rs
+++ b/nostrweet-integration-tests/src/tests/tweet_fetch.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
-use nostr_sdk::prelude::*;
 use nostr_sdk::Event;
+use nostr_sdk::prelude::*;
 use tracing::{debug, info};
 
 use crate::test_runner::TestContext;

--- a/nostrweet/src/commands/clear_cache.rs
+++ b/nostrweet/src/commands/clear_cache.rs
@@ -5,12 +5,12 @@ use tokio::fs;
 use tracing::{debug, info, warn};
 
 /// Clear the tweet cache (removes all downloaded tweets and media)
-pub async fn execute(output_dir: &PathBuf, force: bool) -> Result<()> {
+pub async fn execute(data_dir: &PathBuf, force: bool) -> Result<()> {
     if !force {
         // Ask for confirmation
         print!(
             "Are you sure you want to delete all cached tweets and media from {path}? [y/N] ",
-            path = output_dir.display()
+            path = data_dir.display()
         );
         io::stdout().flush().context("Failed to flush stdout")?;
 
@@ -26,7 +26,7 @@ pub async fn execute(output_dir: &PathBuf, force: bool) -> Result<()> {
     }
 
     // Get list of files
-    let mut entries = fs::read_dir(output_dir)
+    let mut entries = fs::read_dir(data_dir)
         .await
         .context("Failed to read output directory")?;
 

--- a/nostrweet/src/commands/daemon.rs
+++ b/nostrweet/src/commands/daemon.rs
@@ -826,9 +826,9 @@ async fn post_tweet_to_nostr_with_state(
     };
 
     // Create resolver for mentions
-    let cache_dir = Some(state.config.data_dir.to_string_lossy().to_string());
+    let data_dir = Some(state.config.data_dir.to_string_lossy().to_string());
     let mut resolver =
-        crate::nostr_linking::NostrLinkResolver::new(cache_dir, state.config.mnemonic.clone());
+        crate::nostr_linking::NostrLinkResolver::new(data_dir, state.config.mnemonic.clone());
 
     // Format content
     let (content, mentioned_pubkeys) =

--- a/nostrweet/src/commands/daemon.rs
+++ b/nostrweet/src/commands/daemon.rs
@@ -583,9 +583,13 @@ async fn process_user_tweets(state: &DaemonState, username: &str) -> Result<(u64
         }
 
         // Download media
-        let _media_results = crate::media::download_media(&enriched_tweet, &state.config.data_dir)
-            .await
-            .with_context(|| format!("Failed to download media for tweet {tweet_id}"))?;
+        let _media_results = crate::media::download_media(
+            &enriched_tweet,
+            &state.config.data_dir,
+            Some(&state.config.bearer_token),
+        )
+        .await
+        .with_context(|| format!("Failed to download media for tweet {tweet_id}"))?;
 
         // Save tweet
         storage::save_tweet(&enriched_tweet, &state.config.data_dir)?;

--- a/nostrweet/src/commands/daemon.rs
+++ b/nostrweet/src/commands/daemon.rs
@@ -22,6 +22,7 @@ pub struct DaemonConfig {
     pub poll_interval: u64,
     pub output_dir: std::path::PathBuf,
     pub mnemonic: Option<String>,
+    pub bearer_token: String,
 }
 
 /// Per-user state tracking
@@ -136,6 +137,7 @@ pub async fn execute(
     poll_interval: u64,
     output_dir: &Path,
     mnemonic: Option<&str>,
+    bearer_token: &str,
 ) -> Result<()> {
     info!(
         "Starting daemon v2 for {user_count} users with {poll_interval} second base interval",
@@ -149,6 +151,7 @@ pub async fn execute(
         poll_interval,
         output_dir: output_dir.to_path_buf(),
         mnemonic: mnemonic.map(|s| s.to_string()),
+        bearer_token: bearer_token.to_string(),
     });
 
     // Initialize daemon state
@@ -206,7 +209,8 @@ async fn init_daemon(config: Arc<DaemonConfig>) -> Result<DaemonState> {
     // Initialize Twitter client
     info!("Initializing Twitter client");
     let twitter_client = Arc::new(
-        TwitterClient::new(&config.output_dir).context("Failed to initialize Twitter client")?,
+        TwitterClient::new(&config.output_dir, &config.bearer_token)
+            .context("Failed to initialize Twitter client")?,
     );
 
     // Connect to Nostr relays

--- a/nostrweet/src/commands/daemon.rs
+++ b/nostrweet/src/commands/daemon.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::signal;
-use tokio::sync::{oneshot, Mutex, RwLock};
+use tokio::sync::{Mutex, RwLock, oneshot};
 use tokio::time;
 use tracing::{debug, error, info, trace, warn};
 
@@ -314,7 +314,9 @@ async fn run_daemon_v2(state: DaemonState) -> Result<()> {
                                 reset_time,
                                 remaining,
                             } => {
-                                warn!("Rate limit detected for @{username}, will back off until {reset_time:?} (remaining: {remaining:?})");
+                                warn!(
+                                    "Rate limit detected for @{username}, will back off until {reset_time:?} (remaining: {remaining:?})"
+                                );
                             }
                             TwitterError::UserNotFound { username: user } => {
                                 error!("User @{user} not found, will continue retrying");
@@ -469,7 +471,9 @@ async fn process_user_v2(state: DaemonState, username: String) -> Result<()> {
                     stats.total_tweets_posted += posted;
 
                     if *downloaded > 0 || *posted > 0 {
-                        info!("User @{username}: downloaded {downloaded} tweets, posted {posted} to Nostr");
+                        info!(
+                            "User @{username}: downloaded {downloaded} tweets, posted {posted} to Nostr"
+                        );
                     }
                 }
                 Err(e) => {

--- a/nostrweet/src/commands/fetch_profile.rs
+++ b/nostrweet/src/commands/fetch_profile.rs
@@ -6,10 +6,10 @@ use crate::storage;
 use crate::twitter;
 
 /// Fetch a user's profile and save it to a file
-pub async fn execute(username: &str, output_dir: &Path, bearer_token: &str) -> Result<()> {
+pub async fn execute(username: &str, data_dir: &Path, bearer_token: &str) -> Result<()> {
     info!("Downloading profile for {username}");
 
-    let client = twitter::TwitterClient::new(output_dir, bearer_token)
+    let client = twitter::TwitterClient::new(data_dir, bearer_token)
         .context("Failed to initialize Twitter client")?;
     let user = client
         .get_user_by_username(username)
@@ -17,7 +17,7 @@ pub async fn execute(username: &str, output_dir: &Path, bearer_token: &str) -> R
         .context("Failed to download profile")?;
 
     let saved_path =
-        storage::save_user_profile(&user, output_dir).context("Failed to save user profile")?;
+        storage::save_user_profile(&user, data_dir).context("Failed to save user profile")?;
 
     info!(
         "Successfully saved profile for {username} to {path}",

--- a/nostrweet/src/commands/fetch_profile.rs
+++ b/nostrweet/src/commands/fetch_profile.rs
@@ -6,11 +6,11 @@ use crate::storage;
 use crate::twitter;
 
 /// Fetch a user's profile and save it to a file
-pub async fn execute(username: &str, output_dir: &Path) -> Result<()> {
+pub async fn execute(username: &str, output_dir: &Path, bearer_token: &str) -> Result<()> {
     info!("Downloading profile for {username}");
 
-    let client =
-        twitter::TwitterClient::new(output_dir).context("Failed to initialize Twitter client")?;
+    let client = twitter::TwitterClient::new(output_dir, bearer_token)
+        .context("Failed to initialize Twitter client")?;
     let user = client
         .get_user_by_username(username)
         .await

--- a/nostrweet/src/commands/fetch_tweet.rs
+++ b/nostrweet/src/commands/fetch_tweet.rs
@@ -8,7 +8,12 @@ use crate::storage;
 use crate::twitter;
 
 /// Fetch a single tweet and its media
-pub async fn execute(tweet_url_or_id: &str, output_dir: &Path, skip_profiles: bool) -> Result<()> {
+pub async fn execute(
+    tweet_url_or_id: &str,
+    output_dir: &Path,
+    skip_profiles: bool,
+    bearer_token: &str,
+) -> Result<()> {
     // Extract tweet ID from URL or use as is
     let tweet_id = twitter::parse_tweet_id(tweet_url_or_id).context("Failed to parse tweet ID")?;
 
@@ -27,7 +32,7 @@ pub async fn execute(tweet_url_or_id: &str, output_dir: &Path, skip_profiles: bo
         info!("Downloading tweet {tweet_id}");
 
         // Download the tweet and its media
-        let client = twitter::TwitterClient::new(output_dir)
+        let client = twitter::TwitterClient::new(output_dir, bearer_token)
             .context("Failed to initialize Twitter client")?;
 
         // Download the tweet
@@ -113,7 +118,7 @@ pub async fn execute(tweet_url_or_id: &str, output_dir: &Path, skip_profiles: bo
             );
 
             let username_vec: Vec<String> = usernames.into_iter().collect();
-            let client = twitter::TwitterClient::new(output_dir)
+            let client = twitter::TwitterClient::new(output_dir, bearer_token)
                 .context("Failed to initialize Twitter client for profile downloads")?;
 
             match client

--- a/nostrweet/src/commands/fetch_tweet.rs
+++ b/nostrweet/src/commands/fetch_tweet.rs
@@ -10,7 +10,7 @@ use crate::twitter;
 /// Fetch a single tweet and its media
 pub async fn execute(
     tweet_url_or_id: &str,
-    output_dir: &Path,
+    data_dir: &Path,
     skip_profiles: bool,
     bearer_token: &str,
 ) -> Result<()> {
@@ -18,8 +18,7 @@ pub async fn execute(
     let tweet_id = twitter::parse_tweet_id(tweet_url_or_id).context("Failed to parse tweet ID")?;
 
     // Check if we already have the tweet data locally
-    let tweet = if let Some(existing_path) =
-        storage::find_existing_tweet_json(&tweet_id, output_dir)
+    let tweet = if let Some(existing_path) = storage::find_existing_tweet_json(&tweet_id, data_dir)
     {
         // Use existing tweet data
         debug!(
@@ -32,7 +31,7 @@ pub async fn execute(
         info!("Downloading tweet {tweet_id}");
 
         // Download the tweet and its media
-        let client = twitter::TwitterClient::new(output_dir, bearer_token)
+        let client = twitter::TwitterClient::new(data_dir, bearer_token)
             .context("Failed to initialize Twitter client")?;
 
         // Download the tweet
@@ -43,7 +42,7 @@ pub async fn execute(
 
         // Enrich the tweet with referenced tweet data
         if let Err(e) = client
-            .enrich_referenced_tweets(&mut downloaded_tweet, Some(output_dir))
+            .enrich_referenced_tweets(&mut downloaded_tweet, Some(data_dir))
             .await
         {
             debug!("Failed to enrich referenced tweets: {e}");
@@ -53,7 +52,7 @@ pub async fn execute(
         info!("Successfully retrieved tweet data");
 
         // Save tweet data
-        let saved_path = storage::save_tweet(&downloaded_tweet, output_dir)
+        let saved_path = storage::save_tweet(&downloaded_tweet, data_dir)
             .context("Failed to save tweet data")?;
         debug!("Saved tweet data to {path}", path = saved_path.display());
 
@@ -61,7 +60,7 @@ pub async fn execute(
     };
 
     // Download media
-    let media_results = media::download_media(&tweet, output_dir)
+    let media_results = media::download_media(&tweet, data_dir)
         .await
         .context("Failed to download media")?;
 
@@ -89,22 +88,22 @@ pub async fn execute(
     if expected_media_count == 0 {
         info!(
             "Tweet processed (no media items found/expected) in {path}",
-            path = output_dir.display()
+            path = data_dir.display()
         );
     } else if actual_media_count == expected_media_count {
         info!(
             "Tweet and all {actual_media_count} media item(s) successfully processed in {path}",
-            path = output_dir.display()
+            path = data_dir.display()
         );
     } else if actual_media_count > 0 {
         info!(
             "Tweet processed with {actual_media_count} out of {expected_media_count} media item(s) successfully processed in {path}",
-            path = output_dir.display()
+            path = data_dir.display()
         );
     } else {
         info!(
             "Tweet processed, but all {expected_media_count} media item(s) failed to download, in {path}",
-            path = output_dir.display()
+            path = data_dir.display()
         );
     }
 
@@ -118,13 +117,10 @@ pub async fn execute(
             );
 
             let username_vec: Vec<String> = usernames.into_iter().collect();
-            let client = twitter::TwitterClient::new(output_dir, bearer_token)
+            let client = twitter::TwitterClient::new(data_dir, bearer_token)
                 .context("Failed to initialize Twitter client for profile downloads")?;
 
-            match client
-                .download_user_profiles(&username_vec, output_dir)
-                .await
-            {
+            match client.download_user_profiles(&username_vec, data_dir).await {
                 Ok(profiles) => {
                     if !profiles.is_empty() {
                         info!(

--- a/nostrweet/src/commands/fetch_tweet.rs
+++ b/nostrweet/src/commands/fetch_tweet.rs
@@ -60,7 +60,7 @@ pub async fn execute(
     };
 
     // Download media
-    let media_results = media::download_media(&tweet, data_dir)
+    let media_results = media::download_media(&tweet, data_dir, Some(bearer_token))
         .await
         .context("Failed to download media")?;
 

--- a/nostrweet/src/commands/list_tweets.rs
+++ b/nostrweet/src/commands/list_tweets.rs
@@ -8,8 +8,8 @@ use crate::datetime_utils::{format_for_display, from_unix_timestamp};
 use crate::twitter;
 
 /// List all downloaded tweets in the cache
-pub async fn execute(output_dir: &PathBuf) -> Result<()> {
-    let mut entries = fs::read_dir(output_dir)
+pub async fn execute(data_dir: &PathBuf) -> Result<()> {
+    let mut entries = fs::read_dir(data_dir)
         .await
         .context("Failed to read output directory")?;
 
@@ -28,7 +28,7 @@ pub async fn execute(output_dir: &PathBuf) -> Result<()> {
     }
 
     if tweet_files.is_empty() {
-        info!("No tweets found in {path}", path = output_dir.display());
+        info!("No tweets found in {path}", path = data_dir.display());
         return Ok(());
     }
 
@@ -58,7 +58,7 @@ pub async fn execute(output_dir: &PathBuf) -> Result<()> {
     println!(
         "Found {} tweets in {}",
         sorted_files.len(),
-        output_dir.display()
+        data_dir.display()
     );
     println!("{:-^80}", "");
 

--- a/nostrweet/src/commands/post_profile_to_nostr.rs
+++ b/nostrweet/src/commands/post_profile_to_nostr.rs
@@ -6,7 +6,12 @@ use tracing::{debug, info};
 
 use crate::{keys, nostr, nostr_profile, storage};
 
-pub async fn execute(username: &str, relays: &[String], output_dir: &Path) -> Result<()> {
+pub async fn execute(
+    username: &str,
+    relays: &[String],
+    output_dir: &Path,
+    mnemonic: Option<&str>,
+) -> Result<()> {
     info!(
         "Attempting to post profile for user '{}' to Nostr.",
         username
@@ -33,7 +38,7 @@ pub async fn execute(username: &str, relays: &[String], output_dir: &Path) -> Re
         storage::load_user_from_file(&profile_path).context("Failed to load user profile")?;
 
     // Get Nostr keys
-    let keys = keys::get_keys_for_tweet(&user.id)?;
+    let keys = keys::get_keys_for_tweet(&user.id, mnemonic)?;
 
     // Initialize Nostr client
     let client = nostr::initialize_nostr_client(&keys, relays).await?;

--- a/nostrweet/src/commands/post_profile_to_nostr.rs
+++ b/nostrweet/src/commands/post_profile_to_nostr.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use nostr_sdk::prelude::*;
 use tracing::{debug, info};
 

--- a/nostrweet/src/commands/post_profile_to_nostr.rs
+++ b/nostrweet/src/commands/post_profile_to_nostr.rs
@@ -9,7 +9,7 @@ use crate::{keys, nostr, nostr_profile, storage};
 pub async fn execute(
     username: &str,
     relays: &[String],
-    output_dir: &Path,
+    data_dir: &Path,
     mnemonic: Option<&str>,
 ) -> Result<()> {
     info!(
@@ -18,7 +18,7 @@ pub async fn execute(
     );
 
     // Find the latest profile for the user
-    let latest_profile_path = storage::find_latest_user_profile(username, output_dir)
+    let latest_profile_path = storage::find_latest_user_profile(username, data_dir)
         .context("Failed to find latest user profile")?;
 
     let Some(profile_path) = latest_profile_path else {
@@ -53,7 +53,7 @@ pub async fn execute(
         .context("Failed to build metadata event")?;
 
     // Save the event locally before publishing
-    storage::save_nostr_event(&event, output_dir).context("Failed to save nostr event locally")?;
+    storage::save_nostr_event(&event, data_dir).context("Failed to save nostr event locally")?;
 
     // Publish the event
     let event_id = client

--- a/nostrweet/src/commands/post_tweet.rs
+++ b/nostrweet/src/commands/post_tweet.rs
@@ -8,6 +8,7 @@ pub async fn execute(
     output_dir: &Path,
     force: bool,
     skip_profiles: bool,
+    mnemonic: Option<&str>,
 ) -> Result<()> {
     super::post_tweet_to_nostr::execute(
         tweet_url_or_id,
@@ -16,6 +17,7 @@ pub async fn execute(
         output_dir,
         force,
         skip_profiles,
+        mnemonic,
     )
     .await
     .context("Failed to post tweet to Nostr")

--- a/nostrweet/src/commands/post_tweet.rs
+++ b/nostrweet/src/commands/post_tweet.rs
@@ -6,22 +6,20 @@ pub async fn execute(
     tweet_url_or_id: &str,
     relays: &[String],
     blossom_servers: &[String],
-    output_dir: &Path,
+    data_dir: &Path,
     force: bool,
     skip_profiles: bool,
     mnemonic: Option<&str>,
-    cache_dir: Option<&Path>,
     bearer_token: Option<&str>,
 ) -> Result<()> {
     super::post_tweet_to_nostr::execute(
         tweet_url_or_id,
         relays,
         blossom_servers,
-        output_dir,
+        data_dir,
         force,
         skip_profiles,
         mnemonic,
-        cache_dir,
         bearer_token,
     )
     .await

--- a/nostrweet/src/commands/post_tweet.rs
+++ b/nostrweet/src/commands/post_tweet.rs
@@ -9,6 +9,8 @@ pub async fn execute(
     force: bool,
     skip_profiles: bool,
     mnemonic: Option<&str>,
+    cache_dir: Option<&Path>,
+    bearer_token: Option<&str>,
 ) -> Result<()> {
     super::post_tweet_to_nostr::execute(
         tweet_url_or_id,
@@ -18,6 +20,8 @@ pub async fn execute(
         force,
         skip_profiles,
         mnemonic,
+        cache_dir,
+        bearer_token,
     )
     .await
     .context("Failed to post tweet to Nostr")

--- a/nostrweet/src/commands/post_tweet.rs
+++ b/nostrweet/src/commands/post_tweet.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use std::path::Path;
 
+#[allow(clippy::too_many_arguments)]
 pub async fn execute(
     tweet_url_or_id: &str,
     relays: &[String],

--- a/nostrweet/src/commands/post_tweet_to_nostr.rs
+++ b/nostrweet/src/commands/post_tweet_to_nostr.rs
@@ -58,11 +58,10 @@ pub async fn execute(
     tweet_url_or_id: &str,
     relays: &[String],
     blossom_servers: &[String],
-    output_dir: &Path,
+    data_dir: &Path,
     force: bool,
     skip_profiles: bool,
     mnemonic: Option<&str>,
-    cache_dir: Option<&Path>,
     bearer_token: Option<&str>,
 ) -> Result<()> {
     // Parse tweet ID from URL or ID string
@@ -72,7 +71,7 @@ pub async fn execute(
     info!("Processing tweet {tweet_id} for Nostr publishing");
 
     // Check if we already have a Nostr event for this tweet
-    if let Some(event_info) = nostr::check_existing_nostr_event(output_dir, &tweet_id).await? {
+    if let Some(event_info) = nostr::check_existing_nostr_event(data_dir, &tweet_id).await? {
         if force {
             info!(
                 "Force flag enabled: Overwriting existing Nostr event for tweet {tweet_id} (previous event ID: {event_id})",
@@ -90,7 +89,7 @@ pub async fn execute(
 
     // First, check if we have already downloaded the tweet
     let mut tweet =
-        if let Some(existing_path) = storage::find_existing_tweet_json(&tweet_id, output_dir) {
+        if let Some(existing_path) = storage::find_existing_tweet_json(&tweet_id, data_dir) {
             debug!(
                 "Found existing tweet data at {path}",
                 path = existing_path.display()
@@ -103,7 +102,7 @@ pub async fn execute(
 
             let bearer = bearer_token
                 .ok_or_else(|| anyhow::anyhow!("Bearer token required to download tweet"))?;
-            let client = twitter::TwitterClient::new(output_dir, bearer)
+            let client = twitter::TwitterClient::new(data_dir, bearer)
                 .context("Failed to initialize Twitter client")?;
 
             let tweet = client
@@ -112,7 +111,7 @@ pub async fn execute(
                 .with_context(|| format!("Failed to download tweet {tweet_id}"))?;
 
             // Save the tweet locally
-            let saved_path = storage::save_tweet(&tweet, output_dir)
+            let saved_path = storage::save_tweet(&tweet, data_dir)
                 .with_context(|| format!("Failed to save tweet data for {tweet_id}"))?;
             debug!("Saved tweet data to {path}", path = saved_path.display());
 
@@ -126,29 +125,13 @@ pub async fn execute(
             for ref_tweet in ref_tweets {
                 if ref_tweet.data.is_none() {
                     debug!(
-                        "Looking for referenced tweet {id} in output_dir: {dir}",
+                        "Looking for referenced tweet {id} in data_dir: {dir}",
                         id = ref_tweet.id,
-                        dir = output_dir.display()
+                        dir = data_dir.display()
                     );
 
                     // First check in the current output directory
-                    let mut existing_path =
-                        storage::find_existing_tweet_json(&ref_tweet.id, output_dir);
-
-                    // If not found, check in all other directories
-                    if existing_path.is_none() {
-                        debug!(
-                            "Referenced tweet {id} not found in output_dir, checking other directories",
-                            id = ref_tweet.id
-                        );
-                        existing_path = storage::find_tweet_in_all_directories(
-                            &ref_tweet.id,
-                            output_dir,
-                            cache_dir,
-                        );
-                    }
-
-                    if let Some(path) = existing_path {
+                    if let Some(path) = storage::find_existing_tweet_json(&ref_tweet.id, data_dir) {
                         match storage::load_tweet_from_file(&path) {
                             Ok(referenced_tweet) => {
                                 debug!(
@@ -228,7 +211,7 @@ pub async fn execute(
     if need_extended_media {
         debug!("Fetching extended media information for tweet {tweet_id}");
         if let Some(bearer) = bearer_token {
-            let twitter_client_result = twitter::TwitterClient::new(output_dir, bearer);
+            let twitter_client_result = twitter::TwitterClient::new(data_dir, bearer);
             if let Ok(twitter_client_instance) = twitter_client_result {
                 let extended_tweet = twitter_client_instance
                     .get_tweet_with_media(&tweet_id)
@@ -257,18 +240,18 @@ pub async fn execute(
         debug!("No media URLs found in tweet");
     }
 
-    // Locate or download media files in flat output_dir, fallback to nested tweets dir
+    // Locate or download media files in flat data_dir, fallback to nested tweets dir
     let mut media_files = Vec::new();
     for url in &tweet_media_urls {
         let filename = url.split('/').next_back().unwrap_or("media");
-        let flat_path = output_dir.join(filename);
-        let nested_path = output_dir.join("tweets").join(&tweet_id).join(filename);
+        let flat_path = data_dir.join(filename);
+        let nested_path = data_dir.join("tweets").join(&tweet_id).join(filename);
         let file_path = if flat_path.exists() {
             flat_path.clone()
         } else if nested_path.exists() {
             nested_path.clone()
         } else {
-            // Download into flat output_dir
+            // Download into flat data_dir
             let resp = reqwest::get(url).await?;
             let bytes = resp.bytes().await?;
             fs::write(&flat_path, &bytes).await?;
@@ -299,12 +282,9 @@ pub async fn execute(
         blossom_urls.clone()
     };
 
-    // Use provided cache directory or fall back to output directory
-    let cache_path = cache_dir.unwrap_or(output_dir);
-
     // Create a resolver for Twitter username to Nostr pubkey mapping
     let mut resolver = crate::nostr_linking::NostrLinkResolver::new(
-        Some(cache_path.to_string_lossy().to_string()),
+        Some(data_dir.to_string_lossy().to_string()),
         mnemonic.map(|s| s.to_string()),
     );
 
@@ -383,7 +363,7 @@ pub async fn execute(
         let event = final_builder.sign(&keys).await?;
 
         // Save the event locally before publishing
-        storage::save_nostr_event(&event, output_dir)
+        storage::save_nostr_event(&event, data_dir)
             .context("Failed to save nostr event locally")?;
 
         debug!("Successfully created event with tweet's original timestamp");
@@ -465,7 +445,7 @@ pub async fn execute(
     };
 
     // Save event info to file
-    let event_info_path = nostr::save_nostr_event_info(&event_info, output_dir).await?;
+    let event_info_path = nostr::save_nostr_event_info(&event_info, data_dir).await?;
     debug!(
         "Saved Nostr event info to {path}",
         path = event_info_path.display()
@@ -486,7 +466,7 @@ pub async fn execute(
 
             // Filter profiles that need to be posted
             let profiles_to_post = nostr_profile::filter_profiles_to_post(
-                usernames, &client, output_dir, force, mnemonic,
+                usernames, &client, data_dir, force, mnemonic,
             )
             .await?;
 
@@ -495,7 +475,7 @@ pub async fn execute(
                 let posted_count = nostr_profile::post_referenced_profiles(
                     &profiles_to_post,
                     &client,
-                    output_dir,
+                    data_dir,
                     mnemonic,
                 )
                 .await?;

--- a/nostrweet/src/commands/post_tweet_to_nostr.rs
+++ b/nostrweet/src/commands/post_tweet_to_nostr.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, ensure, Context, Result};
+use anyhow::{Context, Result, bail, ensure};
 // No Keys import needed as we're using it through the keys module
 use std::path::Path;
 use tokio::fs;
@@ -334,7 +334,9 @@ pub async fn execute(
         // Parse the tweet's creation date
         // First check if the tweet has a creation date
         if tweet.created_at.is_empty() {
-            bail!("No creation date found in tweet - cannot create Nostr event without a valid timestamp");
+            bail!(
+                "No creation date found in tweet - cannot create Nostr event without a valid timestamp"
+            );
         }
 
         // Parse the ISO 8601 date into a timestamp

--- a/nostrweet/src/commands/post_tweet_to_nostr.rs
+++ b/nostrweet/src/commands/post_tweet_to_nostr.rs
@@ -53,6 +53,7 @@ pub fn create_nostr_event_tags(
     Ok(tags)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn execute(
     tweet_url_or_id: &str,
     relays: &[String],

--- a/nostrweet/src/commands/post_user_to_nostr.rs
+++ b/nostrweet/src/commands/post_user_to_nostr.rs
@@ -255,6 +255,8 @@ pub async fn execute_with_options(
             options.force,
             true, // Always skip profiles here, we'll post them all at once at the end
             mnemonic,
+            None, // Use default cache dir
+            None, // Bearer token not needed for cached tweets
         )
         .await
         {

--- a/nostrweet/src/commands/post_user_to_nostr.rs
+++ b/nostrweet/src/commands/post_user_to_nostr.rs
@@ -11,21 +11,21 @@ use crate::profile_collector;
 use crate::storage;
 
 /// Find all tweet JSON files for a specific user in the output directory
-async fn find_user_tweets(username: &str, output_dir: &Path) -> Result<Vec<PathBuf>> {
+async fn find_user_tweets(username: &str, data_dir: &Path) -> Result<Vec<PathBuf>> {
     ensure!(
-        output_dir.exists(),
+        data_dir.exists(),
         "Output directory does not exist: {path}",
-        path = output_dir.display()
+        path = data_dir.display()
     );
 
     // Normalize the username for consistent matching
     let normalized_username = username.trim_start_matches('@').to_lowercase();
 
     // Read all entries in the directory
-    let entries = fs::read_dir(output_dir).with_context(|| {
+    let entries = fs::read_dir(data_dir).with_context(|| {
         format!(
             "Failed to read output directory: {path}",
-            path = output_dir.display()
+            path = data_dir.display()
         )
     })?;
 
@@ -83,7 +83,7 @@ pub async fn execute(
     username: &str,
     relays: &[String],
     blossom_servers: &[String],
-    output_dir: &Path,
+    data_dir: &Path,
     force: bool,
     skip_profiles: bool,
     mnemonic: Option<&str>,
@@ -97,7 +97,7 @@ pub async fn execute(
         username,
         relays,
         blossom_servers,
-        output_dir,
+        data_dir,
         options,
         mnemonic,
     )
@@ -109,7 +109,7 @@ pub async fn execute_with_options(
     username: &str,
     relays: &[String],
     blossom_servers: &[String],
-    output_dir: &Path,
+    data_dir: &Path,
     options: PostUserOptions,
     mnemonic: Option<&str>,
 ) -> Result<()> {
@@ -119,7 +119,7 @@ pub async fn execute_with_options(
     info!("Finding cached tweets for user @{username}");
 
     // Find all tweets for this user
-    let tweet_files = find_user_tweets(username, output_dir).await?;
+    let tweet_files = find_user_tweets(username, data_dir).await?;
 
     ensure!(
         !tweet_files.is_empty(),
@@ -251,11 +251,10 @@ pub async fn execute_with_options(
             &tweet_id,
             relays,
             blossom_servers,
-            output_dir,
+            data_dir,
             options.force,
             true, // Always skip profiles here, we'll post them all at once at the end
             mnemonic,
-            None, // Use default cache dir
             None, // Bearer token not needed for cached tweets
         )
         .await
@@ -345,7 +344,7 @@ pub async fn execute_with_options(
             let profiles_to_post = nostr_profile::filter_profiles_to_post(
                 all_referenced_users,
                 &client,
-                output_dir,
+                data_dir,
                 options.force,
                 mnemonic,
             )
@@ -356,7 +355,7 @@ pub async fn execute_with_options(
                 let posted_count = nostr_profile::post_referenced_profiles(
                     &profiles_to_post,
                     &client,
-                    output_dir,
+                    data_dir,
                     mnemonic,
                 )
                 .await?;

--- a/nostrweet/src/commands/post_user_to_nostr.rs
+++ b/nostrweet/src/commands/post_user_to_nostr.rs
@@ -1,4 +1,4 @@
-use anyhow::{ensure, Context, Result};
+use anyhow::{Context, Result, ensure};
 use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/nostrweet/src/commands/update_relay_list.rs
+++ b/nostrweet/src/commands/update_relay_list.rs
@@ -6,11 +6,11 @@ use crate::nostr;
 
 /// Executes the relay list update command.
 /// Updates the relay list for the master/root key derived from the mnemonic.
-pub async fn execute(relays: &[String]) -> Result<()> {
+pub async fn execute(relays: &[String], mnemonic: Option<&str>) -> Result<()> {
     info!("Updating relay list for master key");
 
     // Get the master key from mnemonic/private key (using None for root derivation)
-    let keys = keys::get_keys_for_tweet("")?; // Empty string gives us the root key
+    let keys = keys::get_keys_for_tweet("", mnemonic)?; // Empty string gives us the root key
 
     // Initialize Nostr client with keys and relays
     let client = nostr::initialize_nostr_client(&keys, relays)

--- a/nostrweet/src/commands/user_tweets.rs
+++ b/nostrweet/src/commands/user_tweets.rs
@@ -21,6 +21,7 @@ pub async fn execute(
     max_results: Option<u32>,
     days: Option<u32>,
     skip_profiles: bool,
+    bearer_token: &str,
 ) -> Result<()> {
     // Clean username (remove @ if present)
     let username = username.trim_start_matches('@');
@@ -28,8 +29,8 @@ pub async fn execute(
     info!("Fetching recent tweets for user @{username}");
 
     // Create Twitter client
-    let client =
-        twitter::TwitterClient::new(output_dir).context("Failed to initialize Twitter client")?;
+    let client = twitter::TwitterClient::new(output_dir, bearer_token)
+        .context("Failed to initialize Twitter client")?;
 
     // Fetch tweets from user's timeline
     let tweets = client

--- a/nostrweet/src/commands/user_tweets.rs
+++ b/nostrweet/src/commands/user_tweets.rs
@@ -105,7 +105,7 @@ pub async fn execute(
         }
 
         // Download media for tweet and its references
-        let media_results = media::download_media(&tweet_to_save, data_dir)
+        let media_results = media::download_media(&tweet_to_save, data_dir, Some(bearer_token))
             .await
             .with_context(|| format!("Failed to download media for tweet {tweet_id}"))?;
         let new_media = media_results.iter().filter(|r| !r.from_cache).count();

--- a/nostrweet/src/commands/user_tweets.rs
+++ b/nostrweet/src/commands/user_tweets.rs
@@ -127,7 +127,9 @@ pub async fn execute(
         } else if actual_media_count == expected_media_count {
             debug!("Tweet {tweet_id}: All {actual_media_count} media item(s) processed.");
         } else {
-            debug!("Tweet {tweet_id}: {actual_media_count} out of {expected_media_count} media item(s) processed.");
+            debug!(
+                "Tweet {tweet_id}: {actual_media_count} out of {expected_media_count} media item(s) processed."
+            );
         }
 
         media_files_count += actual_media_count;

--- a/nostrweet/src/error_utils.rs
+++ b/nostrweet/src/error_utils.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 
 /// File I/O error handling utilities
 /// JSON serialization/parsing error handling utilities
@@ -93,7 +93,7 @@ mod tests {
         assert!(result.is_none());
 
         // Set a test env var
-        std::env::set_var("TEST_VAR", "test_value");
+        unsafe { std::env::set_var("TEST_VAR", "test_value") };
         let result = get_optional_env_var("TEST_VAR");
         assert_eq!(result, Some("test_value".to_string()));
     }

--- a/nostrweet/src/error_utils.rs
+++ b/nostrweet/src/error_utils.rs
@@ -59,7 +59,7 @@ pub fn create_http_client_with_context() -> Result<reqwest::Client> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde::{Deserialize, Serialize};
+    use serde::Deserialize;
 
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
     struct TestData {

--- a/nostrweet/src/error_utils.rs
+++ b/nostrweet/src/error_utils.rs
@@ -37,18 +37,6 @@ pub async fn parse_http_response_json<T: DeserializeOwned>(
         .with_context(|| format!("Failed to parse {api_desc} response"))
 }
 
-/// Environment variable handling utilities
-///
-/// Get required environment variable with contextual error handling
-pub fn get_required_env_var(var_name: &str) -> Result<String> {
-    std::env::var(var_name).with_context(|| format!("{var_name} environment variable not set"))
-}
-
-/// Get optional environment variable, returning None if not set or empty
-pub fn get_optional_env_var(var_name: &str) -> Option<String> {
-    std::env::var(var_name).ok().filter(|v| !v.is_empty())
-}
-
 /// Create HTTP client with contextual error handling
 pub fn create_http_client_with_context() -> Result<reqwest::Client> {
     reqwest::Client::builder()
@@ -80,24 +68,6 @@ mod tests {
 
         let parsed_data: TestData = parse_json_with_context(&json_str, "test data").unwrap();
         assert_eq!(parsed_data, data);
-    }
-
-    #[test]
-    fn test_env_var_handling() {
-        // Test required env var (this will likely fail, which is expected)
-        let result = get_required_env_var("NONEXISTENT_VAR");
-        assert!(result.is_err());
-
-        // Test optional env var
-        let result = get_optional_env_var("NONEXISTENT_VAR");
-        assert!(result.is_none());
-
-        // Test with a commonly available env var (PATH is usually set on all systems)
-        // This avoids needing to set env vars in the test
-        if std::env::var("PATH").is_ok() {
-            let result = get_optional_env_var("PATH");
-            assert!(result.is_some());
-        }
     }
 
     #[test]

--- a/nostrweet/src/error_utils.rs
+++ b/nostrweet/src/error_utils.rs
@@ -92,10 +92,12 @@ mod tests {
         let result = get_optional_env_var("NONEXISTENT_VAR");
         assert!(result.is_none());
 
-        // Set a test env var
-        unsafe { std::env::set_var("TEST_VAR", "test_value") };
-        let result = get_optional_env_var("TEST_VAR");
-        assert_eq!(result, Some("test_value".to_string()));
+        // Test with a commonly available env var (PATH is usually set on all systems)
+        // This avoids needing to set env vars in the test
+        if std::env::var("PATH").is_ok() {
+            let result = get_optional_env_var("PATH");
+            assert!(result.is_some());
+        }
     }
 
     #[test]

--- a/nostrweet/src/filename_utils.rs
+++ b/nostrweet/src/filename_utils.rs
@@ -33,9 +33,9 @@ pub fn media_filename(username: &str, media_key: &str, file_extension: &str) -> 
 }
 
 /// Sanitize and create full file path
-pub fn sanitized_file_path(output_dir: &Path, filename: &str) -> PathBuf {
+pub fn sanitized_file_path(data_dir: &Path, filename: &str) -> PathBuf {
     let sanitized_filename = sanitize(filename);
-    output_dir.join(sanitized_filename)
+    data_dir.join(sanitized_filename)
 }
 
 /// Generate a filename for Nostr event JSON files

--- a/nostrweet/src/keys.rs
+++ b/nostrweet/src/keys.rs
@@ -77,10 +77,12 @@ mod tests {
     #[test]
     fn test_derive_key_for_twitter_user() -> Result<()> {
         // Set test mnemonic
-        env::set_var(
-            "NOSTRWEET_MNEMONIC",
-            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
-        );
+        unsafe {
+            env::set_var(
+                "NOSTRWEET_MNEMONIC",
+                "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+            );
+        }
 
         // Test that same user ID produces same keys
         let keys1 = derive_key_for_twitter_user("123456")?;
@@ -97,10 +99,12 @@ mod tests {
     #[test]
     fn test_get_keys_for_tweet() -> Result<()> {
         // Set test mnemonic
-        env::set_var(
-            "NOSTRWEET_MNEMONIC",
-            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
-        );
+        unsafe {
+            env::set_var(
+                "NOSTRWEET_MNEMONIC",
+                "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+            );
+        }
 
         // Test that get_keys_for_tweet derives correctly
         let keys = get_keys_for_tweet("123456")?;
@@ -114,10 +118,12 @@ mod tests {
 
     #[test]
     fn test_deterministic_account_mapping() -> Result<()> {
-        env::set_var(
-            "NOSTRWEET_MNEMONIC",
-            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
-        );
+        unsafe {
+            env::set_var(
+                "NOSTRWEET_MNEMONIC",
+                "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+            );
+        }
 
         // Test that numeric Twitter IDs map consistently
         let test_cases = vec![

--- a/nostrweet/src/keys.rs
+++ b/nostrweet/src/keys.rs
@@ -78,15 +78,16 @@ pub fn derive_key_for_twitter_user_with_mnemonic(
 
 /// Derives a deterministic Nostr private key for a Twitter user
 /// using NIP-06 compliant BIP39/BIP32 derivation
-/// Reads mnemonic from NOSTRWEET_MNEMONIC environment variable
-pub fn derive_key_for_twitter_user(twitter_user_id: &str) -> Result<Keys> {
-    derive_key_for_twitter_user_with_mnemonic(twitter_user_id, None, None)
+/// If mnemonic is None, reads from NOSTRWEET_MNEMONIC environment variable
+pub fn derive_key_for_twitter_user(twitter_user_id: &str, mnemonic: Option<&str>) -> Result<Keys> {
+    derive_key_for_twitter_user_with_mnemonic(twitter_user_id, mnemonic, None)
 }
 
 /// Creates a Keys instance by deriving from the Twitter user ID using NIP-06
-pub fn get_keys_for_tweet(twitter_user_id: &str) -> Result<Keys> {
+/// If mnemonic is None, reads from NOSTRWEET_MNEMONIC environment variable
+pub fn get_keys_for_tweet(twitter_user_id: &str, mnemonic: Option<&str>) -> Result<Keys> {
     debug!("Deriving NIP-06 compliant key for Twitter user {twitter_user_id}");
-    derive_key_for_twitter_user(twitter_user_id)
+    derive_key_for_twitter_user(twitter_user_id, mnemonic)
 }
 
 #[cfg(test)]

--- a/nostrweet/src/keys.rs
+++ b/nostrweet/src/keys.rs
@@ -68,13 +68,13 @@ pub fn derive_key_for_twitter_user_with_mnemonic(
 
 /// Derives a deterministic Nostr private key for a Twitter user
 /// using NIP-06 compliant BIP39/BIP32 derivation
-/// If mnemonic is None, reads from NOSTRWEET_MNEMONIC environment variable
+/// Requires mnemonic to be provided as a parameter
 pub fn derive_key_for_twitter_user(twitter_user_id: &str, mnemonic: Option<&str>) -> Result<Keys> {
     derive_key_for_twitter_user_with_mnemonic(twitter_user_id, mnemonic, None)
 }
 
 /// Creates a Keys instance by deriving from the Twitter user ID using NIP-06
-/// If mnemonic is None, reads from NOSTRWEET_MNEMONIC environment variable
+/// Requires mnemonic to be provided as a parameter
 pub fn get_keys_for_tweet(twitter_user_id: &str, mnemonic: Option<&str>) -> Result<Keys> {
     debug!("Deriving NIP-06 compliant key for Twitter user {twitter_user_id}");
     derive_key_for_twitter_user(twitter_user_id, mnemonic)

--- a/nostrweet/src/main.rs
+++ b/nostrweet/src/main.rs
@@ -31,6 +31,10 @@ struct Cli {
     #[arg(short, long, env = "NOSTRWEET_OUTPUT_DIR", global = true)]
     output_dir: Option<PathBuf>,
 
+    /// BIP39 mnemonic phrase for deriving Nostr keys
+    #[arg(short = 'm', long, env = "NOSTRWEET_MNEMONIC", global = true)]
+    mnemonic: Option<String>,
+
     /// Verbose output
     #[arg(short, long, global = true)]
     verbose: bool,
@@ -347,6 +351,7 @@ async fn main() -> Result<()> {
                 &output_dir,
                 force,
                 skip_profiles,
+                args.mnemonic.as_deref(),
             )
             .await?
         }
@@ -364,6 +369,7 @@ async fn main() -> Result<()> {
                 &output_dir,
                 force,
                 skip_profiles,
+                args.mnemonic.as_deref(),
             )
             .await?
         }
@@ -381,14 +387,21 @@ async fn main() -> Result<()> {
                 &output_dir,
                 force,
                 skip_profiles,
+                args.mnemonic.as_deref(),
             )
             .await?
         }
         Commands::PostProfileToNostr { username, relays } => {
-            commands::post_profile_to_nostr::execute(&username, &relays, &output_dir).await?
+            commands::post_profile_to_nostr::execute(
+                &username,
+                &relays,
+                &output_dir,
+                args.mnemonic.as_deref(),
+            )
+            .await?
         }
         Commands::UpdateRelayList { relays } => {
-            commands::update_relay_list::execute(&relays).await?
+            commands::update_relay_list::execute(&relays, args.mnemonic.as_deref()).await?
         }
         Commands::ShowTweet(cmd) => cmd.execute(&output_dir).await?,
         Commands::Daemon {
@@ -397,8 +410,15 @@ async fn main() -> Result<()> {
             blossom_servers,
             poll_interval,
         } => {
-            commands::daemon::execute(users, relays, blossom_servers, poll_interval, &output_dir)
-                .await?
+            commands::daemon::execute(
+                users,
+                relays,
+                blossom_servers,
+                poll_interval,
+                &output_dir,
+                args.mnemonic.as_deref(),
+            )
+            .await?
         }
         Commands::Utils { command } => match command {
             UtilsCommands::QueryEvents {

--- a/nostrweet/src/main.rs
+++ b/nostrweet/src/main.rs
@@ -32,7 +32,7 @@ struct Cli {
     data_dir: Option<PathBuf>,
 
     /// Twitter API bearer token for authentication
-    #[arg(short = 'b', long, env = "TWITTER_BEARER_TOKEN", global = true)]
+    #[arg(long, env = "TWITTER_BEARER_TOKEN", global = true)]
     bearer_token: Option<String>,
 
     /// BIP39 mnemonic phrase for deriving Nostr keys
@@ -113,7 +113,7 @@ enum Commands {
         relays: Vec<String>,
 
         /// Blossom server addresses for media uploads (comma-separated)
-        #[arg(short, long, value_delimiter = ',', env = "NOSTRWEET_BLOSSOM_SERVERS")]
+        #[arg(long, value_delimiter = ',', env = "NOSTRWEET_BLOSSOM_SERVERS")]
         blossom_servers: Vec<String>,
 
         /// Force overwrite of existing Nostr event
@@ -142,7 +142,7 @@ enum Commands {
         relays: Vec<String>,
 
         /// Blossom server addresses for media uploads (comma-separated)
-        #[arg(short, long, value_delimiter = ',', env = "NOSTRWEET_BLOSSOM_SERVERS")]
+        #[arg(long, value_delimiter = ',', env = "NOSTRWEET_BLOSSOM_SERVERS")]
         blossom_servers: Vec<String>,
 
         /// Force overwrite of existing Nostr events
@@ -171,7 +171,7 @@ enum Commands {
         relays: Vec<String>,
 
         /// Blossom server addresses for media uploads (comma-separated)
-        #[arg(short, long, value_delimiter = ',', env = "NOSTRWEET_BLOSSOM_SERVERS")]
+        #[arg(long, value_delimiter = ',', env = "NOSTRWEET_BLOSSOM_SERVERS")]
         blossom_servers: Vec<String>,
 
         /// Force overwrite of existing Nostr event
@@ -227,7 +227,7 @@ enum Commands {
         relays: Vec<String>,
 
         /// Blossom server addresses for media uploads
-        #[arg(short = 'b', long = "blossom-server", action = clap::ArgAction::Append)]
+        #[arg(long = "blossom-server", action = clap::ArgAction::Append)]
         blossom_servers: Vec<String>,
 
         /// Seconds between polling cycles

--- a/nostrweet/src/main.rs
+++ b/nostrweet/src/main.rs
@@ -324,7 +324,6 @@ async fn main() -> Result<()> {
         Commands::FetchProfile { .. }
             | Commands::FetchTweet { .. }
             | Commands::UserTweets { .. }
-            | Commands::ShowTweet(_)
             | Commands::Daemon { .. }
     );
 

--- a/nostrweet/src/media.rs
+++ b/nostrweet/src/media.rs
@@ -1,13 +1,13 @@
 use crate::error_utils::{create_http_client_with_context, get_optional_env_var};
 use crate::filename_utils::{media_filename, sanitized_file_path};
 use crate::twitter::{Media as TwitterMedia, Tweet};
-use anyhow::{ensure, Context, Result};
+use anyhow::{Context, Result, ensure};
 use flate2::read::GzDecoder;
 use futures_util::StreamExt;
 use reqwest::Client;
 use std::io::Read;
 use std::path::{Path, PathBuf};
-use tokio::fs::{metadata, File};
+use tokio::fs::{File, metadata};
 use tokio::io::AsyncWriteExt;
 use tokio_util::io::StreamReader;
 use tracing::{debug, info, warn};

--- a/nostrweet/src/nostr.rs
+++ b/nostrweet/src/nostr.rs
@@ -460,10 +460,10 @@ pub async fn initialize_nostr_client(keys: &Keys, relays: &[String]) -> Result<C
 
 /// Check if a tweet has already been posted to Nostr
 pub async fn check_existing_nostr_event(
-    output_dir: &Path,
+    data_dir: &Path,
     tweet_id: &str,
 ) -> Result<Option<NostrEventInfo>> {
-    let nostr_dir = output_dir.join("nostr");
+    let nostr_dir = data_dir.join("nostr");
     let event_info_path = nostr_dir.join(format!("{tweet_id}.json"));
 
     if event_info_path.exists() {
@@ -483,9 +483,9 @@ pub async fn check_existing_nostr_event(
 /// Save Nostr event information to file
 pub async fn save_nostr_event_info(
     event_info: &NostrEventInfo,
-    output_dir: &Path,
+    data_dir: &Path,
 ) -> Result<PathBuf> {
-    let nostr_dir = output_dir.join("nostr");
+    let nostr_dir = data_dir.join("nostr");
 
     if !nostr_dir.exists() {
         fs::create_dir_all(&nostr_dir).await.with_context(|| {

--- a/nostrweet/src/nostr.rs
+++ b/nostrweet/src/nostr.rs
@@ -1,14 +1,14 @@
 use crate::nostr_linking::NostrLinkResolver;
-use anyhow::{bail, Context, Result};
-use base64::engine::general_purpose::STANDARD;
+use anyhow::{Context, Result, bail};
 use base64::Engine;
-use nostr_sdk::nips::nip65::RelayMetadata;
+use base64::engine::general_purpose::STANDARD;
 use nostr_sdk::ToBech32;
+use nostr_sdk::nips::nip65::RelayMetadata;
 use nostr_sdk::{
     Alphabet, Client, Event, EventBuilder, Filter, Keys, Kind, PublicKey, RelayUrl,
     SingleLetterTag, SubscriptionId, Tag, Timestamp, Url,
 };
-use reqwest::{header::RETRY_AFTER, StatusCode};
+use reqwest::{StatusCode, header::RETRY_AFTER};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
@@ -382,7 +382,9 @@ pub async fn upload_media_to_blossom(
                                 upload_success = true;
                                 debug!("Successfully uploaded to Blossom server: {server_url}");
                             } else {
-                                warn!("Blossom response missing URL field and nip94_event url tag: {json}");
+                                warn!(
+                                    "Blossom response missing URL field and nip94_event url tag: {json}"
+                                );
                             }
                         } else {
                             warn!("Blossom server error {status}", status = r.status());

--- a/nostrweet/src/nostr_linking.rs
+++ b/nostrweet/src/nostr_linking.rs
@@ -1,6 +1,4 @@
 use crate::keys::derive_key_for_twitter_user;
-#[cfg(test)]
-use crate::keys::derive_key_for_twitter_user_with_mnemonic;
 use crate::storage::{find_latest_user_profile, load_user_from_file};
 use anyhow::{Context, Result};
 use nostr_sdk::PublicKey;
@@ -12,28 +10,23 @@ use tracing::debug;
 /// This helps avoid repeated lookups and key derivations
 pub struct NostrLinkResolver {
     /// Maps Twitter username to Nostr public key
-    #[cfg(test)]
-    pub(crate) username_to_pubkey: HashMap<String, PublicKey>,
-    #[cfg(not(test))]
     username_to_pubkey: HashMap<String, PublicKey>,
-
     /// Maps Twitter user ID to Nostr public key
-    #[cfg(test)]
-    pub(crate) user_id_to_pubkey: HashMap<String, PublicKey>,
-    #[cfg(not(test))]
     user_id_to_pubkey: HashMap<String, PublicKey>,
-
     /// Cache directory to search for user profiles
     cache_dir: Option<String>,
+    /// Mnemonic for deriving keys
+    mnemonic: Option<String>,
 }
 
 impl NostrLinkResolver {
-    /// Create a new resolver with optional cache directory
-    pub fn new(cache_dir: Option<String>) -> Self {
+    /// Create a new resolver with optional cache directory and mnemonic
+    pub fn new(cache_dir: Option<String>, mnemonic: Option<String>) -> Self {
         Self {
             username_to_pubkey: HashMap::new(),
             user_id_to_pubkey: HashMap::new(),
             cache_dir,
+            mnemonic,
         }
     }
 
@@ -58,9 +51,10 @@ impl NostrLinkResolver {
                 // Load the user profile to get the user ID
                 if let Ok(user) = load_user_from_file(&profile_path) {
                     // Derive the Nostr key from the Twitter user ID
-                    let keys = derive_key_for_twitter_user(&user.id).with_context(|| {
-                        format!("Failed to derive key for Twitter user {username}")
-                    })?;
+                    let keys = derive_key_for_twitter_user(&user.id, self.mnemonic.as_deref())
+                        .with_context(|| {
+                            format!("Failed to derive key for Twitter user {username}")
+                        })?;
                     let pubkey = keys.public_key();
 
                     // Cache both username and user ID mappings
@@ -86,7 +80,7 @@ impl NostrLinkResolver {
         }
 
         // Derive the key
-        let keys = derive_key_for_twitter_user(user_id)
+        let keys = derive_key_for_twitter_user(user_id, self.mnemonic.as_deref())
             .with_context(|| format!("Failed to derive key for Twitter user ID {user_id}"))?;
         let pubkey = keys.public_key();
 
@@ -109,25 +103,7 @@ impl NostrLinkResolver {
             return Ok(());
         }
 
-        let keys = derive_key_for_twitter_user(user_id)
-            .with_context(|| format!("Failed to derive key for Twitter user {username}"))?;
-        let pubkey = keys.public_key();
-
-        self.username_to_pubkey.insert(username.to_string(), pubkey);
-        self.user_id_to_pubkey.insert(user_id.to_string(), pubkey);
-
-        Ok(())
-    }
-
-    /// Test-only method to add a known user with a specific mnemonic
-    #[cfg(test)]
-    pub(crate) fn add_known_user_with_mnemonic(
-        &mut self,
-        username: &str,
-        user_id: &str,
-        mnemonic: &str,
-    ) -> Result<()> {
-        let keys = derive_key_for_twitter_user_with_mnemonic(user_id, Some(mnemonic), None)
+        let keys = derive_key_for_twitter_user(user_id, self.mnemonic.as_deref())
             .with_context(|| format!("Failed to derive key for Twitter user {username}"))?;
         let pubkey = keys.public_key();
 
@@ -141,116 +117,15 @@ impl NostrLinkResolver {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::keys::derive_key_for_twitter_user_with_mnemonic;
     use crate::twitter::User;
     use std::fs;
     use tempfile::TempDir;
 
     const TEST_MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
 
-    /// Test version of NostrLinkResolver that uses test mnemonic
-    struct TestNostrLinkResolver {
-        resolver: NostrLinkResolver,
-    }
-
-    impl TestNostrLinkResolver {
-        fn new(cache_dir: Option<String>) -> Self {
-            Self {
-                resolver: NostrLinkResolver::new(cache_dir),
-            }
-        }
-
-        fn resolve_user_id(&mut self, user_id: &str) -> Result<PublicKey> {
-            // Check cache first
-            if let Some(pubkey) = self.resolver.user_id_to_pubkey.get(user_id) {
-                return Ok(*pubkey);
-            }
-
-            // Derive key using test mnemonic
-            let keys =
-                derive_key_for_twitter_user_with_mnemonic(user_id, Some(TEST_MNEMONIC), None)
-                    .with_context(|| {
-                        format!("Failed to derive key for Twitter user ID {user_id}")
-                    })?;
-            let pubkey = keys.public_key();
-            self.resolver
-                .user_id_to_pubkey
-                .insert(user_id.to_string(), pubkey);
-            Ok(pubkey)
-        }
-
-        fn resolve_username(&mut self, username: &str) -> Result<Option<PublicKey>> {
-            // Check cache first
-            if let Some(pubkey) = self.resolver.username_to_pubkey.get(username) {
-                return Ok(Some(*pubkey));
-            }
-
-            // Check if we have a cached profile
-            self.resolver
-                .resolve_username_from_cache(username, TEST_MNEMONIC)
-        }
-
-        fn add_known_user(&mut self, username: &str, user_id: &str) -> Result<()> {
-            let keys =
-                derive_key_for_twitter_user_with_mnemonic(user_id, Some(TEST_MNEMONIC), None)
-                    .with_context(|| format!("Failed to derive key for Twitter user {username}"))?;
-            let pubkey = keys.public_key();
-
-            self.resolver
-                .username_to_pubkey
-                .insert(username.to_string(), pubkey);
-            self.resolver
-                .user_id_to_pubkey
-                .insert(user_id.to_string(), pubkey);
-
-            Ok(())
-        }
-    }
-
-    impl NostrLinkResolver {
-        /// Test helper to resolve username from cache with test mnemonic
-        fn resolve_username_from_cache(
-            &mut self,
-            username: &str,
-            mnemonic: &str,
-        ) -> Result<Option<PublicKey>> {
-            if let Some(ref cache_dir) = self.cache_dir {
-                let path = std::path::Path::new(&cache_dir);
-                if path.exists() {
-                    for entry in fs::read_dir(path)? {
-                        let entry = entry?;
-                        let filename = entry.file_name();
-                        let filename_str = filename.to_string_lossy();
-
-                        if filename_str.contains(&format!("_{username}_profile.json")) {
-                            let content = fs::read_to_string(entry.path())?;
-                            if let Ok(user) = serde_json::from_str::<User>(&content) {
-                                if user.username == username {
-                                    let keys = derive_key_for_twitter_user_with_mnemonic(
-                                        &user.id,
-                                        Some(mnemonic),
-                                        None,
-                                    )
-                                    .with_context(|| {
-                                        format!("Failed to derive key for Twitter user {username}")
-                                    })?;
-                                    let pubkey = keys.public_key();
-                                    self.username_to_pubkey.insert(username.to_string(), pubkey);
-                                    self.user_id_to_pubkey.insert(user.id.clone(), pubkey);
-                                    return Ok(Some(pubkey));
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            Ok(None)
-        }
-    }
-
     #[test]
     fn test_nostr_link_resolver() -> Result<()> {
-        let mut resolver = TestNostrLinkResolver::new(None);
+        let mut resolver = NostrLinkResolver::new(None, Some(TEST_MNEMONIC.to_string()));
 
         // Test user ID resolution
         let pubkey1 = resolver.resolve_user_id("12345")?;
@@ -286,7 +161,7 @@ mod tests {
         fs::write(&file_path, json)?;
 
         // Create resolver with cache directory
-        let mut resolver = TestNostrLinkResolver::new(Some(cache_dir));
+        let mut resolver = NostrLinkResolver::new(Some(cache_dir), Some(TEST_MNEMONIC.to_string()));
 
         // Resolve username should find cached profile
         let pubkey = resolver.resolve_username("cacheduser")?;
@@ -301,8 +176,8 @@ mod tests {
 
     #[test]
     fn test_deterministic_key_derivation() -> Result<()> {
-        let mut resolver1 = TestNostrLinkResolver::new(None);
-        let mut resolver2 = TestNostrLinkResolver::new(None);
+        let mut resolver1 = NostrLinkResolver::new(None, Some(TEST_MNEMONIC.to_string()));
+        let mut resolver2 = NostrLinkResolver::new(None, Some(TEST_MNEMONIC.to_string()));
 
         // Same user ID should produce same pubkey across different resolvers
         let pubkey1 = resolver1.resolve_user_id("555555")?;

--- a/nostrweet/src/nostr_linking.rs
+++ b/nostrweet/src/nostr_linking.rs
@@ -222,7 +222,7 @@ mod tests {
                         let filename = entry.file_name();
                         let filename_str = filename.to_string_lossy();
 
-                        if filename_str.contains(&format!("_{}_profile.json", username)) {
+                        if filename_str.contains(&format!("_{username}_profile.json")) {
                             let content = fs::read_to_string(entry.path())?;
                             if let Ok(user) = serde_json::from_str::<User>(&content) {
                                 if user.username == username {

--- a/nostrweet/src/nostr_linking.rs
+++ b/nostrweet/src/nostr_linking.rs
@@ -13,19 +13,19 @@ pub struct NostrLinkResolver {
     username_to_pubkey: HashMap<String, PublicKey>,
     /// Maps Twitter user ID to Nostr public key
     user_id_to_pubkey: HashMap<String, PublicKey>,
-    /// Cache directory to search for user profiles
-    cache_dir: Option<String>,
+    /// Data directory to search for user profiles
+    data_dir: Option<String>,
     /// Mnemonic for deriving keys
     mnemonic: Option<String>,
 }
 
 impl NostrLinkResolver {
-    /// Create a new resolver with optional cache directory and mnemonic
-    pub fn new(cache_dir: Option<String>, mnemonic: Option<String>) -> Self {
+    /// Create a new resolver with optional data directory and mnemonic
+    pub fn new(data_dir: Option<String>, mnemonic: Option<String>) -> Self {
         Self {
             username_to_pubkey: HashMap::new(),
             user_id_to_pubkey: HashMap::new(),
-            cache_dir,
+            data_dir,
             mnemonic,
         }
     }
@@ -40,9 +40,9 @@ impl NostrLinkResolver {
         }
 
         // Try to find the user profile in cache
-        if let Some(cache_dir) = &self.cache_dir {
-            let cache_path = Path::new(cache_dir);
-            if let Ok(Some(profile_path)) = find_latest_user_profile(username, cache_path) {
+        if let Some(data_dir) = &self.data_dir {
+            let data_path = Path::new(data_dir);
+            if let Ok(Some(profile_path)) = find_latest_user_profile(username, data_path) {
                 debug!(
                     "Found cached profile for @{username} at {profile_path}",
                     profile_path = profile_path.display()
@@ -141,11 +141,11 @@ mod tests {
     }
 
     #[test]
-    fn test_resolver_with_cache_dir() -> Result<()> {
+    fn test_resolver_with_data_dir() -> Result<()> {
         let temp_dir = TempDir::new()?;
-        let cache_dir = temp_dir.path().to_str().unwrap().to_string();
+        let data_dir = temp_dir.path().to_str().unwrap().to_string();
 
-        // Create a mock user profile in the cache
+        // Create a mock user profile in the data directory
         let user = User {
             id: "98765".to_string(),
             username: "cacheduser".to_string(),
@@ -160,8 +160,8 @@ mod tests {
         let json = serde_json::to_string(&user)?;
         fs::write(&file_path, json)?;
 
-        // Create resolver with cache directory
-        let mut resolver = NostrLinkResolver::new(Some(cache_dir), Some(TEST_MNEMONIC.to_string()));
+        // Create resolver with data directory
+        let mut resolver = NostrLinkResolver::new(Some(data_dir), Some(TEST_MNEMONIC.to_string()));
 
         // Resolve username should find cached profile
         let pubkey = resolver.resolve_username("cacheduser")?;

--- a/nostrweet/src/nostr_profile.rs
+++ b/nostrweet/src/nostr_profile.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use nostr_sdk::{prelude::*, Metadata};
+use nostr_sdk::{Metadata, prelude::*};
 use std::collections::HashSet;
 use std::path::Path;
 use tracing::{debug, info};

--- a/nostrweet/src/profile_collector.rs
+++ b/nostrweet/src/profile_collector.rs
@@ -77,12 +77,12 @@ pub fn collect_usernames_from_tweets(tweets: &[Tweet]) -> HashSet<String> {
 /// Filters out usernames that already have cached profiles
 pub async fn filter_uncached_usernames(
     usernames: HashSet<String>,
-    cache_dir: &Path,
+    data_dir: &Path,
 ) -> Result<Vec<String>> {
     let mut uncached = Vec::new();
 
     for username in usernames {
-        if find_latest_user_profile(&username, cache_dir)?.is_none() {
+        if find_latest_user_profile(&username, data_dir)?.is_none() {
             debug!("Profile for @{username} not found in cache, will download");
             uncached.push(username);
         } else {

--- a/nostrweet/src/storage.rs
+++ b/nostrweet/src/storage.rs
@@ -36,15 +36,17 @@ pub fn find_existing_tweet_json(tweet_id: &str, output_dir: &Path) -> Option<Pat
 
 /// Search for a tweet JSON file across all likely directories
 /// This is useful for finding referenced tweets that might be in different locations
-pub fn find_tweet_in_all_directories(tweet_id: &str) -> Option<PathBuf> {
+pub fn find_tweet_in_all_directories(
+    tweet_id: &str,
+    output_dir: &Path,
+    cache_dir: Option<&Path>,
+) -> Option<PathBuf> {
     // List of directories to search in priority order
     let search_dirs = vec![
-        // 1. Configured output directory from environment
-        std::env::var("NOSTRWEET_OUTPUT_DIR")
-            .ok()
-            .map(PathBuf::from),
-        // 2. Configured cache directory
-        std::env::var("NOSTRWEET_CACHE_DIR").ok().map(PathBuf::from),
+        // 1. Primary output directory
+        Some(output_dir.to_path_buf()),
+        // 2. Optional cache directory if different
+        cache_dir.map(PathBuf::from),
     ];
 
     // Search in each directory

--- a/nostrweet/src/storage.rs
+++ b/nostrweet/src/storage.rs
@@ -75,10 +75,10 @@ pub fn load_tweet_from_file(file_path: &Path) -> Result<Tweet> {
     Ok(tweet)
 }
 
-/// Checks if a tweet ID has been marked as "not found" in the cache.
-pub fn is_tweet_not_found(tweet_id: &str, cache_dir: &Path) -> bool {
+/// Checks if a tweet ID has been marked as "not found" in the data directory.
+pub fn is_tweet_not_found(tweet_id: &str, data_dir: &Path) -> bool {
     let filename = not_found_filename(tweet_id);
-    let file_path = sanitized_file_path(cache_dir, &filename);
+    let file_path = sanitized_file_path(data_dir, &filename);
     let exists = file_path.exists();
     if exists {
         debug!(
@@ -89,8 +89,7 @@ pub fn is_tweet_not_found(tweet_id: &str, cache_dir: &Path) -> bool {
     exists
 }
 
-/// Marks a tweet ID as "not found" in the cache by creating a .not_found file.
-/// Assumes cache_dir exists.
+/// Load a user profile from a JSON file.
 pub fn load_user_from_file(path: &Path) -> Result<User> {
     let file = std::fs::File::open(path)?;
     let reader = std::io::BufReader::new(file);
@@ -98,15 +97,15 @@ pub fn load_user_from_file(path: &Path) -> Result<User> {
     Ok(user)
 }
 
-/// Find the latest (highest) tweet ID for a specific user in the cache
-pub fn find_latest_tweet_id_for_user(username: &str, cache_dir: &Path) -> Result<Option<String>> {
-    let cache_dir_str = cache_dir
+/// Find the latest (highest) tweet ID for a specific user in the data directory
+pub fn find_latest_tweet_id_for_user(username: &str, data_dir: &Path) -> Result<Option<String>> {
+    let data_dir_str = data_dir
         .to_str()
-        .context("Cache directory path contains invalid UTF-8")?;
+        .context("Data directory path contains invalid UTF-8")?;
 
     // Pattern to match tweet files for this user
     // Format: YYYYMMDD_HHMMSS_username_tweetid.json
-    let glob_pattern = format!("{cache_dir_str}/*_{username}_*.json");
+    let glob_pattern = format!("{data_dir_str}/*_{username}_*.json");
 
     let mut latest_tweet_id: Option<String> = None;
 
@@ -142,11 +141,11 @@ pub fn find_latest_tweet_id_for_user(username: &str, cache_dir: &Path) -> Result
     Ok(latest_tweet_id)
 }
 
-pub fn find_latest_user_profile(username: &str, cache_dir: &Path) -> Result<Option<PathBuf>> {
-    let cache_dir_str = cache_dir
+pub fn find_latest_user_profile(username: &str, data_dir: &Path) -> Result<Option<PathBuf>> {
+    let data_dir_str = data_dir
         .to_str()
-        .context("Cache directory path contains invalid UTF-8")?;
-    let glob_pattern = format!("{cache_dir_str}/??????????????_{username}_*.json");
+        .context("Data directory path contains invalid UTF-8")?;
+    let glob_pattern = format!("{data_dir_str}/??????????????_{username}_*.json");
 
     let mut latest_file: Option<(chrono::NaiveDateTime, PathBuf)> = None;
 
@@ -211,9 +210,9 @@ pub fn save_nostr_event(event: &nostr_sdk::Event, data_dir: &Path) -> Result<Pat
     Ok(file_path)
 }
 
-pub fn mark_tweet_as_not_found(tweet_id: &str, cache_dir: &Path) -> Result<()> {
+pub fn mark_tweet_as_not_found(tweet_id: &str, data_dir: &Path) -> Result<()> {
     let filename = not_found_filename(tweet_id);
-    let file_path = sanitized_file_path(cache_dir, &filename);
+    let file_path = sanitized_file_path(data_dir, &filename);
 
     // Create an empty file. fs::write will create or truncate.
     fs::write(&file_path, "").with_context(|| {

--- a/nostrweet/src/twitter.rs
+++ b/nostrweet/src/twitter.rs
@@ -1,8 +1,8 @@
 use crate::error_utils::{
     create_http_client_with_context, get_required_env_var, parse_http_response_json,
 };
-use anyhow::{bail, Context, Result};
-use backoff::{backoff::Backoff, ExponentialBackoffBuilder};
+use anyhow::{Context, Result, bail};
+use backoff::{ExponentialBackoffBuilder, backoff::Backoff};
 use regex::Regex;
 use reqwest::{Client, StatusCode};
 use serde::{Deserialize, Serialize};
@@ -299,7 +299,9 @@ impl TwitterClient {
                         let sleep_duration =
                             self.calculate_sleep_duration_with_jitter(backoff_time);
 
-                        debug!("Network timeout connecting to Twitter API for {resource_id}. Retrying in {sleep_duration:?} (attempt {attempt}/{max_attempts})");
+                        debug!(
+                            "Network timeout connecting to Twitter API for {resource_id}. Retrying in {sleep_duration:?} (attempt {attempt}/{max_attempts})"
+                        );
                         tokio::time::sleep(sleep_duration).await;
                         continue;
                     } else {
@@ -318,7 +320,10 @@ impl TwitterClient {
                 attempt += 1;
 
                 if attempt >= max_attempts {
-                    debug!("Maximum retry attempts ({max_attempts}) reached for {resource_id}, rate limit reset: {rate_limit_reset:?}", rate_limit_reset = rate_limits.reset);
+                    debug!(
+                        "Maximum retry attempts ({max_attempts}) reached for {resource_id}, rate limit reset: {rate_limit_reset:?}",
+                        rate_limit_reset = rate_limits.reset
+                    );
                     return Err(TwitterError::RateLimit {
                         reset_time: rate_limits.reset,
                         remaining: rate_limits.remaining,
@@ -366,20 +371,24 @@ impl TwitterClient {
                 let sleep_duration =
                     self.calculate_sleep_duration_with_jitter(Duration::from_secs(base_wait_secs));
 
-                info!("Rate limited by Twitter API for {resource_id}. Limit: {limit:?}, Remaining: {remaining:?}, Reset: {reset:?}. Retrying in {sleep_duration:?} (attempt {attempt}/{max_attempts})",
-                      limit = rate_limits.limit,
-                      remaining = rate_limits.remaining,
-                      reset = rate_limits.reset);
+                info!(
+                    "Rate limited by Twitter API for {resource_id}. Limit: {limit:?}, Remaining: {remaining:?}, Reset: {reset:?}. Retrying in {sleep_duration:?} (attempt {attempt}/{max_attempts})",
+                    limit = rate_limits.limit,
+                    remaining = rate_limits.remaining,
+                    reset = rate_limits.reset
+                );
                 tokio::time::sleep(sleep_duration).await;
                 continue;
             }
 
             // Check for other errors
             if response.status().is_success() {
-                debug!("Received Twitter API response for {resource_id} with limits: {limit:?}/{remaining:?} until {reset:?}",
-                       limit = rate_limits.limit,
-                       remaining = rate_limits.remaining,
-                       reset = rate_limits.reset);
+                debug!(
+                    "Received Twitter API response for {resource_id} with limits: {limit:?}/{remaining:?} until {reset:?}",
+                    limit = rate_limits.limit,
+                    remaining = rate_limits.remaining,
+                    reset = rate_limits.reset
+                );
             } else {
                 let status_code = response.status().as_u16();
                 let error_message = format!(
@@ -848,8 +857,10 @@ impl TwitterClient {
                 .take(requested_count as usize)
                 .collect());
         } else if !cached_tweets.is_empty() {
-            debug!("Found {cached_count} cached tweets for user {username}, but need {requested_count}",
-                cached_count = cached_tweets.len());
+            debug!(
+                "Found {cached_count} cached tweets for user {username}, but need {requested_count}",
+                cached_count = cached_tweets.len()
+            );
         }
 
         // If we get here, we need to fetch from the API
@@ -921,7 +932,9 @@ impl TwitterClient {
         let tweet_count = tweets.len();
         match tweet_count.cmp(&(requested_count as usize)) {
             std::cmp::Ordering::Less => {
-                debug!("Returning {tweet_count} tweets for user {username} (requested {requested_count})");
+                debug!(
+                    "Returning {tweet_count} tweets for user {username} (requested {requested_count})"
+                );
             }
             std::cmp::Ordering::Equal => {
                 debug!(
@@ -1116,7 +1129,9 @@ impl TwitterClient {
         let base = format!("{TWITTER_API_BASE}/users/{user_id}/tweets?max_results={max_results}");
 
         // Build URL with common parameters
-        let params = format!("&expansions={COMMON_EXPANSIONS}&media.fields={COMMON_MEDIA_FIELDS}&tweet.fields={COMMON_TWEET_FIELDS}&user.fields={COMMON_USER_FIELDS}");
+        let params = format!(
+            "&expansions={COMMON_EXPANSIONS}&media.fields={COMMON_MEDIA_FIELDS}&tweet.fields={COMMON_TWEET_FIELDS}&user.fields={COMMON_USER_FIELDS}"
+        );
 
         // Add pagination token if provided
         let token_param =

--- a/nostrweet/src/twitter.rs
+++ b/nostrweet/src/twitter.rs
@@ -574,7 +574,7 @@ impl TwitterClient {
     async fn get_tweet_internal(&self, tweet_id: &str) -> Result<Tweet> {
         // First check if we can find the tweet in any known directory
         // Use cache_dir as both output and cache dir for backward compatibility
-        let cache = self.cache_dir.as_ref().map(|p| p.as_path());
+        let cache = self.cache_dir.as_deref();
         let output = cache.unwrap_or(Path::new("./downloads"));
         if let Some(existing_path) =
             crate::storage::find_tweet_in_all_directories(tweet_id, output, cache)

--- a/nostrweet/src/twitter.rs
+++ b/nostrweet/src/twitter.rs
@@ -275,7 +275,7 @@ impl TwitterClient {
                     attempt += 1;
 
                     // Check if we've hit the max retry attempts
-                    if attempt >= max_attempts {
+                    if attempt > max_attempts {
                         return Err(anyhow::Error::new(err)).with_context(|| {
                             format!(
                                 "Failed to send request to Twitter API after {attempt} attempts"
@@ -317,7 +317,7 @@ impl TwitterClient {
             if response.status() == StatusCode::TOO_MANY_REQUESTS {
                 attempt += 1;
 
-                if attempt >= max_attempts {
+                if attempt > max_attempts {
                     debug!(
                         "Maximum retry attempts ({max_attempts}) reached for {resource_id}, rate limit reset: {rate_limit_reset:?}",
                         rate_limit_reset = rate_limits.reset
@@ -365,6 +365,9 @@ impl TwitterClient {
                         .unwrap_or(Duration::from_secs(5 * (attempt as u64)))
                         .as_secs()
                 });
+
+                // Cap the wait time at 30 minutes (1800 seconds) to avoid excessive delays
+                let base_wait_secs = base_wait_secs.min(1800);
 
                 let sleep_duration =
                     self.calculate_sleep_duration_with_jitter(Duration::from_secs(base_wait_secs));

--- a/nostrweet/tests/e2e_test.sh
+++ b/nostrweet/tests/e2e_test.sh
@@ -166,7 +166,7 @@ log "Fetching tweet $TWEET_ID and posting to Nostr..."
 OUTPUT_DIR="$TEST_DIR/downloads"
 
 ./target/release/nostrweet fetch-tweet \
-    --output-dir "$OUTPUT_DIR" \
+    --data-dir "$OUTPUT_DIR" \
     "$TWEET_ID" || {
     error "Failed to fetch tweet"
     exit 1
@@ -186,7 +186,7 @@ log "Posting tweet to Nostr relay..."
 ./target/release/nostrweet post-tweet-to-nostr \
     --private-key "$PRIVATE_KEY" \
     --relays "ws://localhost:$RELAY_PORT" \
-    --output-dir "$OUTPUT_DIR" \
+    --data-dir "$OUTPUT_DIR" \
     "$TWEET_ID" || {
     error "Failed to post tweet to Nostr"
     exit 1
@@ -301,7 +301,7 @@ log "Testing tweet with media..."
 MEDIA_TWEET_ID="1580661436132073472"  # Example tweet with image
 
 ./target/release/nostrweet fetch-tweet \
-    --output-dir "$OUTPUT_DIR" \
+    --data-dir "$OUTPUT_DIR" \
     "$MEDIA_TWEET_ID" || {
     warn "Failed to fetch media tweet (might be deleted/protected)"
 }
@@ -313,7 +313,7 @@ if [ -n "$MEDIA_TWEET_FILE" ]; then
     ./target/release/nostrweet post-tweet-to-nostr \
         --private-key "$PRIVATE_KEY" \
         --relays "ws://localhost:$RELAY_PORT" \
-        --output-dir "$OUTPUT_DIR" \
+        --data-dir "$OUTPUT_DIR" \
         "$MEDIA_TWEET_ID" || {
         warn "Failed to post media tweet to Nostr"
     }

--- a/nostrweet/tests/regression_tests.rs
+++ b/nostrweet/tests/regression_tests.rs
@@ -1033,8 +1033,11 @@ async fn test_douglaz_planet_apes_reply_full_nostr_event() {
     // Verify content formatting
     let content = &event.content;
     assert!(content.contains("🐦 @douglaz:"));
-    assert!(content
-        .contains("@AMAZlNGNATURE So if we want Planet of Apes to happen, we know what to do..."));
+    assert!(
+        content.contains(
+            "@AMAZlNGNATURE So if we want Planet of Apes to happen, we know what to do..."
+        )
+    );
     assert!(content.contains("Original tweet: https://twitter.com/i/status/1929221881929843016"));
 
     // Verify tags
@@ -1590,7 +1593,8 @@ async fn test_show_tweet_with_image_media() {
         .matches("https://pbs.twimg.com/media/GwamxuaXYAARXmF.jpg")
         .count();
     pretty_assertions::assert_eq!(
-        image_url_count, 1,
+        image_url_count,
+        1,
         "Nostr content should contain exactly one instance of the image URL (no duplication): {nostr_content}"
     );
 

--- a/nostrweet/tests/regression_tests.rs
+++ b/nostrweet/tests/regression_tests.rs
@@ -1164,7 +1164,7 @@ async fn test_show_tweet_output_separation() {
             "--",
             "show-tweet",
             "1929266300380967406",
-            "--output-dir",
+            "--data-dir",
             temp_dir.path().to_str().unwrap(),
         ])
         .output()
@@ -1250,7 +1250,7 @@ async fn test_show_tweet_stdout_is_pure_json() {
             "--",
             "show-tweet",
             "1645195402788892674",
-            "--output-dir",
+            "--data-dir",
             temp_dir.path().to_str().unwrap(),
         ])
         .output()
@@ -1325,7 +1325,7 @@ async fn test_show_tweet_pretty_formatting() {
             "--",
             "show-tweet",
             "1929221881929843016",
-            "--output-dir",
+            "--data-dir",
             temp_dir.path().to_str().unwrap(),
             "--pretty",
         ])
@@ -1352,7 +1352,7 @@ async fn test_show_tweet_pretty_formatting() {
             "--",
             "show-tweet",
             "1929221881929843016",
-            "--output-dir",
+            "--data-dir",
             temp_dir.path().to_str().unwrap(),
             "--compact",
         ])
@@ -1550,7 +1550,7 @@ async fn test_show_tweet_with_image_media() {
             "--",
             "show-tweet",
             "1947427270152626319",
-            "--output-dir",
+            "--data-dir",
             temp_dir.path().to_str().unwrap(),
         ])
         .output()
@@ -1710,7 +1710,7 @@ async fn test_show_tweet_with_referenced_tweet_media() {
             "--",
             "show-tweet",
             "1946563939120169182",
-            "--output-dir",
+            "--data-dir",
             temp_dir.path().to_str().unwrap(),
         ])
         .output()


### PR DESCRIPTION
## Summary
- Updated Rust edition to 2024 
- Refactored environment variable handling to use CLI arguments with dependency injection
- Unified output_dir and cache_dir into a single data_dir concept
- Fixed documentation inconsistencies

## Changes

### Rust Edition Update
- Updated Cargo.toml to use Rust edition 2024
- Eliminated unsafe `env::set_var` calls in tests by passing mnemonic as CLI argument

### Environment Variable Refactoring
- Removed `get_required_env_var` and `get_optional_env_var` utility functions
- Changed mnemonic handling to require explicit passing via CLI arguments instead of env fallback
- Added `--bearer-token` CLI argument (with TWITTER_BEARER_TOKEN env fallback via clap)
- Refactored all commands to accept parameters explicitly rather than reading env vars internally

### Directory Unification
- Merged confusing `output_dir` and `cache_dir` into single `data_dir` throughout codebase
- Updated CLI to use `--data-dir` flag (with NOSTRWEET_DATA_DIR env var fallback)
- Maintained backward compatibility with NOSTRWEET_OUTPUT_DIR for existing users
- Simplified storage module by removing dual directory parameters

### Documentation Fixes
- Updated README.md to reflect new CLI arguments and env vars
- Fixed DAEMON.md to correctly document supported environment variables
- Removed incorrect NOSTRWEET_BLOSSOM_SERVERS reference from daemon docs

## Benefits
- Improved testability through dependency injection
- Clearer data flow with explicit parameter passing
- Simpler mental model with unified data directory
- Better compliance with Rust 2024 safety requirements
- More maintainable code without hidden environment dependencies

## Test Plan
- [x] All existing tests pass
- [x] Regression tests updated and passing
- [x] E2E test script updated and working
- [x] Clippy checks pass
- [x] Code properly formatted