### PR TITLE
fix: correct test names in CI workflow to match actual test definitions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -60,7 +60,7 @@ jobs:
     
     strategy:
       matrix:
-        test: [tweet_fetch, profile, daemon, nostr_post, user_tweets, batch_post, cache_management, utils_query]
+        test: [tweet_fetch, profile_sync, daemon_mode, nostr_post, user_tweets, batch_post, cache_management, utils_query]
       fail-fast: false  # Continue running other tests if one fails
     
     env:


### PR DESCRIPTION
## Summary
This PR fixes the failing CI integration tests by correcting the test names in the workflow file.

## Problem
The integration test workflow was using incorrect test names:
- `profile` instead of `profile_sync`  
- `daemon` instead of `daemon_mode`

This was causing CI failures when the extended tests ran on schedule or manual trigger, as seen in [this workflow run](https://github.com/douglaz/nostrweet/actions/runs/17632251490/job/50101698487).

## Solution
Updated the test matrix in `.github/workflows/integration-tests.yml` to use the correct test names that match the actual test definitions in `nostrweet-integration-tests/src/test_runner.rs`.

## Test Plan
- [x] Verified test names match between workflow and code
- [ ] CI checks will validate this fix