### PR TITLE
fix: make expanded_url field optional to handle Twitter API changes

### DIFF
--- a/nostrweet/src/commands/post_profile_to_nostr.rs
+++ b/nostrweet/src/commands/post_profile_to_nostr.rs
@@ -22,10 +22,7 @@ pub async fn execute(
         .context("Failed to find latest user profile")?;
 
     let Some(profile_path) = latest_profile_path else {
-        bail!(
-            "No profile found for user '{username}'",
-            username = username
-        );
+        bail!("No profile found for user '{username}'");
     };
 
     debug!(

--- a/nostrweet/src/commands/post_tweet_to_nostr.rs
+++ b/nostrweet/src/commands/post_tweet_to_nostr.rs
@@ -192,7 +192,7 @@ pub async fn execute(
         if let Some(entities) = &tweet.entities {
             if let Some(urls) = &entities.urls {
                 for url_entity in urls {
-                    let expanded_url = &url_entity.expanded_url;
+                    let expanded_url = url_entity.expanded_url.as_ref().unwrap_or(&url_entity.url);
                     if expanded_url.contains("video")
                         && (expanded_url.contains("twitter.com") || expanded_url.contains("x.com"))
                     {

--- a/nostrweet/src/media.rs
+++ b/nostrweet/src/media.rs
@@ -56,7 +56,8 @@ pub fn extract_media_urls_from_tweet(tweet: &Tweet) -> Vec<String> {
         if let Some(entities) = entities {
             if let Some(urls) = &entities.urls {
                 for url_entity in urls {
-                    let expanded_url = &url_entity.expanded_url;
+                    // Get expanded URL or fall back to original
+                    let expanded_url = url_entity.expanded_url.as_ref().unwrap_or(&url_entity.url);
 
                     // Check if this is a Twitter/X video URL
                     if expanded_url.contains("video")
@@ -103,7 +104,7 @@ pub fn extract_media_urls_from_tweet(tweet: &Tweet) -> Vec<String> {
         if let Some(entities) = &tweet.entities {
             if let Some(urls) = &entities.urls {
                 for url_entity in urls {
-                    let expanded_url = &url_entity.expanded_url;
+                    let expanded_url = url_entity.expanded_url.as_ref().unwrap_or(&url_entity.url);
                     if expanded_url.contains("video")
                         && (expanded_url.contains("twitter.com") || expanded_url.contains("x.com"))
                     {

--- a/nostrweet/src/twitter.rs
+++ b/nostrweet/src/twitter.rs
@@ -137,7 +137,7 @@ pub struct Entities {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct UrlEntity {
     pub url: String,
-    pub expanded_url: String,
+    pub expanded_url: Option<String>,
     pub display_url: String,
 }
 
@@ -1155,7 +1155,7 @@ impl TwitterClient {
                 if let Some(urls) = &mut url_data.urls {
                     for url_item in urls {
                         if let Ok(expanded_url) = resolve_shortened_url(&url_item.url).await {
-                            url_item.expanded_url = expanded_url;
+                            url_item.expanded_url = Some(expanded_url);
                         }
                     }
                 }

--- a/nostrweet/tests/regression_tests.rs
+++ b/nostrweet/tests/regression_tests.rs
@@ -760,8 +760,8 @@ fn test_parse_tweet_with_url() -> anyhow::Result<()> {
         .ok_or_else(|| anyhow::anyhow!("urls missing"))?;
     pretty_assertions::assert_eq!(urls.len(), 1);
     pretty_assertions::assert_eq!(
-        urls[0].expanded_url,
-        "https://example.com/interesting-article"
+        urls[0].expanded_url.as_deref(),
+        Some("https://example.com/interesting-article")
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary
This PR fixes failing integration tests by making the `expanded_url` field optional in Twitter API response parsing.

## Problem
The integration tests were failing with the error:
```
Error: Failed to fetch user timeline
  error decoding response body
  missing field `expanded_url` at line 1 column 1668
```

This indicates Twitter's API has changed and no longer always includes the `expanded_url` field in URL entities.

## Solution
- Made `UrlEntity.expanded_url` field `Option<String>` instead of `String`
- Updated all usages to handle the optional field, falling back to the original URL when expanded_url is not present
- Fixed test fixtures to use `Some()` for expanded_url values

## Test Plan
- [x] All unit tests pass
- [x] Code formatted with `cargo fmt`
- [x] No clippy warnings
- [ ] CI integration tests will validate this fix addresses the issue