### PR TITLE
feat: auto-post and refresh user profiles for monitored Twitter accounts

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,10 +67,8 @@ jobs:
             type=ref,event=tag
             # Latest tag for main branch
             type=raw,value=latest,enable={{is_default_branch}}
-            # SHA prefix for all builds
-            type=sha,prefix={{branch}}-,format=short
-            # SHA without prefix for commits
-            type=sha,format=short
+            # SHA with sha- prefix for all commits
+            type=sha,prefix=sha-,format=short
 
       - name: Tag and push Docker image
         if: github.event_name != 'pull_request'
@@ -102,7 +100,7 @@ jobs:
           echo "### Pull Command:" >> $GITHUB_STEP_SUMMARY
           echo '```bash' >> $GITHUB_STEP_SUMMARY
           SHORT_SHA=$(echo ${{ github.sha }} | head -c 7)
-          echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${SHORT_SHA}" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${SHORT_SHA}" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
   # Job to test the Docker image
@@ -129,7 +127,8 @@ jobs:
       - name: Pull and test Docker image
         run: |
           SHORT_SHA=$(echo ${{ github.sha }} | head -c 7)
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${SHORT_SHA}"
+          # Use sha- prefix for the tag as that's what the metadata action creates
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${SHORT_SHA}"
 
           echo "Pulling image: $IMAGE"
           docker pull $IMAGE

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -109,7 +109,8 @@ jobs:
   test-image:
     needs: build-and-push
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
+    # Only run this job if images were actually pushed (not on PRs)
+    if: github.event_name == 'push'
     permissions:
       contents: read
       packages: read


### PR DESCRIPTION
## Summary
- Adds automatic profile posting for monitored Twitter accounts (previously only posted profiles for referenced users)
- Implements 24-hour profile refresh to keep metadata current
- Ensures monitored accounts like @douglaz have proper Nostr profile metadata

## Problem
The daemon was only posting profiles for users mentioned in tweets, not for the primary monitored accounts. This led to monitored users having no profile metadata on Nostr relays.

## Solution
Added profile management that:
1. Checks if a profile exists when processing a user
2. Posts the profile if it doesn't exist
3. Refreshes profiles every 24 hours to keep them current

## Changes
- Added `last_profile_post_time` and `profile_posted` fields to `UserState` struct
- Added `check_profile_exists()` function to verify if a profile exists on Nostr
- Added profile management functions (`should_refresh_profile`, `ensure_user_profile_posted`, `post_user_profile`)
- Integrated profile checking/posting into the `process_user_v2()` workflow

## Test plan
- [ ] Build and run the daemon locally
- [ ] Verify profile is posted for monitored users on startup
- [ ] Confirm profile refresh works after 24 hours
- [ ] Ensure tweet processing continues normally

🤖 Generated with [Claude Code](https://claude.ai/code)