### PR TITLE
fix: prevent concurrent test runs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,10 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    # Prevent concurrent test runs to avoid conflicts
+    concurrency:
+      group: test-${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -55,12 +59,16 @@ jobs:
 
       - name: Run unit tests
         run: nix develop -c cargo test --lib
+        timeout-minutes: 5
 
       - name: Run integration tests
-        run: nix develop -c cargo test --test '*'
+        # Run tests sequentially with --test-threads=1 to prevent conflicts
+        run: nix develop -c cargo test --test '*' -- --test-threads=1
+        timeout-minutes: 10
 
       - name: Run doc tests
         run: nix develop -c cargo test --doc
+        timeout-minutes: 5
 
   # Integration tests moved to separate workflow: .github/workflows/integration-tests.yml
   # They run on push, PR, schedule, and manual trigger

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,10 +20,15 @@ jobs:
     runs-on: ubuntu-latest
     # Only run if we have Twitter credentials (not on forks)
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.repository == 'douglaz/nostrweet') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-    
+
+    # Prevent concurrent integration test runs
+    concurrency:
+      group: integration-${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: false
+
     env:
       TWITTER_BEARER_TOKEN: ${{ secrets.TWITTER_BEARER_TOKEN }}
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Fixes CI test failures by preventing concurrent test execution.

## Changes
- Add concurrency groups to test jobs to prevent parallel runs
- Run integration tests sequentially with --test-threads=1
- Add timeouts to prevent hanging tests

## Problem
Tests were failing intermittently due to concurrent access to shared resources or test fixtures.

## Solution
By running tests sequentially and preventing concurrent workflow runs, we ensure tests don't interfere with each other.