### PR TITLE
fix: expand media URLs in retweets to show actual video/image links

### DIFF
--- a/nostrweet/src/nostr.rs
+++ b/nostrweet/src/nostr.rs
@@ -1389,11 +1389,14 @@ fn format_retweet(
         content.push_str(&prefix);
 
         // Process the retweeted content
+        // Extract media URLs first so they can be used for URL expansion
+        let tweet_media_urls = crate::media::extract_media_urls_from_tweet(ref_data);
+
         // Legacy formatter without mention resolution
         let mut dummy_resolver = NostrLinkResolver::new(None, None);
         let formatter = TweetFormatter {
             tweet: ref_data,
-            media_urls: &[],
+            media_urls: &tweet_media_urls, // Pass the media URLs for proper expansion
             resolver: &mut dummy_resolver,
         };
         let formatted = formatter.process_content();
@@ -1404,7 +1407,6 @@ fn format_retweet(
 
         // For non-note_tweet cases, add unused media URLs
         if ref_data.note_tweet.is_none() {
-            let tweet_media_urls = crate::media::extract_media_urls_from_tweet(ref_data);
             for url in &tweet_media_urls {
                 if !formatted.used_media_urls.contains(url) {
                     content.push_str(&format!("{url}\n"));


### PR DESCRIPTION
## Summary
- Fixes retweets to show expanded media URLs (videos/images) instead of t.co shortlinks
- Ensures media content in retweets is properly accessible when posted to Nostr

## Problem
When retweeting content that contains media (videos/images), the t.co URLs in the text were not being expanded to show the actual media URLs. This made it difficult for Nostr users to access the media content directly.

Example: 
- Before: `Certíssima ela. https://t.co/sxDlqKciKK`
- After: `Certíssima ela. https://video.twimg.com/ext_tw_video/.../vid/avc1/720x900/Mmc-zSbPPpZX1a8o.mp4`

## Solution
- Extract media URLs from retweeted tweets before formatting
- Pass the extracted media URLs to the TweetFormatter
- The formatter can now properly expand t.co URLs to actual media links

## Test Plan
- [x] Added regression test `test_format_retweet_with_full_content` to ensure media URLs are expanded
- [x] Tested with real tweet ID 1961875988859535529 (a retweet with video)
- [x] All existing regression tests pass
- [x] Manual verification shows video URLs are now properly expanded

## Related Issues
Improves upon the fix in PR #45 by ensuring media content in retweets is fully accessible.