### PR TITLE
chore: run integration tests daily instead of on every commit

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,10 +1,6 @@
 name: Integration Tests
 
 on:
-  push:
-    branches: [master]
-  pull_request:
-    branches: [master]
   workflow_dispatch:  # Allow manual triggering
   schedule:
     # Run daily at 2 AM UTC to catch any Twitter API changes
@@ -18,8 +14,8 @@ jobs:
   integration-tests:
     name: Integration Tests
     runs-on: ubuntu-latest
-    # Only run if we have Twitter credentials (not on forks)
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.repository == 'douglaz/nostrweet') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    # Only run on schedule or manual trigger
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
 
     # Prevent concurrent integration test runs
     concurrency:


### PR DESCRIPTION
## Summary
Changes the integration tests workflow to run only on a daily schedule instead of on every commit and pull request.

## Changes
- Removed `push` and `pull_request` triggers from integration tests workflow
- Kept `schedule` (daily at 2 AM UTC) and `workflow_dispatch` (manual trigger)
- Simplified job conditionals since we only have two trigger types now

## Benefits
- **Reduces CI load**: Integration tests won't run on every commit/PR
- **Preserves Twitter API rate limits**: Tests only run once daily to avoid hitting API limits
- **Maintains quality**: Daily runs still catch any Twitter API changes
- **Manual control**: Can still trigger tests manually when needed via workflow_dispatch

## Testing
- [x] Workflow file is valid YAML
- [x] Conditionals are simplified and correct
- [x] Schedule cron expression unchanged (daily at 2 AM UTC)

This change makes sense because integration tests are primarily for detecting Twitter API changes, which don't need to be checked on every commit. Regular unit tests in CI still run on every commit/PR.