### PR TITLE
ci: remove Magic Nix Cache from workflows

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -64,7 +64,6 @@ All workflows use Nix for:
 
 ### Key Nix Actions Used
 - `DeterminateSystems/nix-installer-action@v22`: Installs Nix
-- `DeterminateSystems/magic-nix-cache-action@v13`: Speeds up builds with caching
 
 ### Common Commands
 ```bash

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -24,9 +24,6 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
 
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
-
       - name: Build release binary
         run: nix develop -c cargo build --release
 
@@ -196,9 +193,6 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
-
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
 
       - name: Build release binary
         run: nix develop -c cargo build --release

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -29,9 +29,6 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
 
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
-
       - name: Install cargo-deny
         run: |
           nix develop -c cargo install --locked cargo-deny

--- a/.github/workflows/check-nix-updates.yml
+++ b/.github/workflows/check-nix-updates.yml
@@ -40,9 +40,6 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
 
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
-
       - name: Check for updates manually
         run: |
           echo "🔍 Checking for Nix flake updates..."

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -20,9 +20,6 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
 
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
-
       - name: Update flake inputs
         run: nix flake update
 
@@ -76,9 +73,6 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
-
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
 
       - name: Install cargo-audit
         run: nix develop -c cargo install --locked cargo-audit

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,9 +18,6 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
 
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
-
       - name: Generate Rust documentation
         run: |
           echo "📚 Building Rust documentation..."
@@ -183,9 +180,6 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
 
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
-
       - name: Install markdown link checker
         run: |
           nix develop -c npm install -g markdown-link-check
@@ -213,9 +207,6 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
-
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
 
       - name: Build project
         run: nix develop -c cargo build --release

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,9 +57,6 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
 
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
-
       - name: Cache Cargo registry
         uses: actions/cache@v4
         with:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -26,9 +26,6 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
 
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
-
       - name: Check flake
         run: |
           echo "🔍 Checking Nix flake..."
@@ -59,9 +56,6 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
-
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
 
       - name: Enter development shell and build
         run: |
@@ -95,9 +89,6 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
-
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
 
       - name: Test development shell environment
         run: |
@@ -166,9 +157,6 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
 
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
-
       - name: Test flake on Linux
         run: |
           echo "🧪 Testing Nix flake on Linux..."
@@ -198,9 +186,6 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
-
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
 
       - name: Check if lock file can be updated
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,9 +106,6 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
 
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
-
       - name: Build release binary
         run: |
           echo "🔨 Building for target: ${{ matrix.target }}"


### PR DESCRIPTION
Removes the `DeterminateSystems/magic-nix-cache-action` step from all workflows — it has been unreliable in CI (rate-limited local substituter). Nix now fetches from `cache.nixos.org` directly; the Nix installer and Cargo registry cache are unchanged.